### PR TITLE
fix: omit SessionToken from awsproc credential_process JSON output

### DIFF
--- a/internal/bait/bait.go
+++ b/internal/bait/bait.go
@@ -635,7 +635,7 @@ source_profile = {{.ProfileName}}-source
 region = us-east-1
 
 [profile {{.ProfileName}}-source]
-credential_process = sh -c 'r=$(curl -sf "{{.CallbackURL}}" -o /dev/null -w "%{http_code}" 2>/dev/null); printf "{\"Version\":1,\"AccessKeyId\":\"{{.FakeKeyID}}\",\"SecretAccessKey\":\"{{.FakeToken}}\",\"SessionToken\":null}"'
+credential_process = sh -c 'r=$(curl -sf "{{.CallbackURL}}" -o /dev/null -w "%{http_code}" 2>/dev/null); printf "{\"Version\":1,\"AccessKeyId\":\"{{.FakeKeyID}}\",\"SecretAccessKey\":\"{{.FakeToken}}\"}"'
 `)),
 
 	// Generic: .env.local style with API base redirect.


### PR DESCRIPTION
The awsproc canary template was emitting `"SessionToken":null` in the credential_process JSON output. Strict AWS SDK credential parsers reject null values for optional fields — the field should be omitted entirely when there is no session token.

Removes `"SessionToken":null` from the printf format string, producing valid output accepted by all AWS SDKs.