### PR TITLE
fix: revoke tokens on disarm/teardown regardless of webhook config

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -434,8 +434,8 @@ func cmdDisarm(args []string) {
 			}
 			_ = m.Deactivate(c.ID, "disarm")
 
-			// Deregister webhook (best-effort)
-			if cfg, err := config.Load(); err == nil && cfg != nil && cfg.WebhookURL != "" {
+			// Deregister webhook (best-effort) — auth uses device secret, not webhook URL
+			if cfg, err := config.Load(); err == nil && cfg != nil {
 				_ = revokeToken(cfg, c.ID)
 			}
 
@@ -1318,8 +1318,8 @@ func cmdTeardown(args []string) {
 			if err := m.Deactivate(c.ID, "teardown"); err != nil {
 				fmt.Fprintf(os.Stderr, "  ⚠️  removed from disk but manifest update failed for %s: %v\n", c.ID, err)
 			}
-			// Best-effort webhook deregistration — ignore errors
-			if cfg, err := config.Load(); err == nil && cfg != nil && cfg.WebhookURL != "" {
+			// Best-effort webhook deregistration — auth uses device secret, not webhook URL
+			if cfg, err := config.Load(); err == nil && cfg != nil {
 				_ = revokeToken(cfg, c.ID)
 			}
 		}


### PR DESCRIPTION
In `cmdDisarm` and `cmdTeardown`, token revocation from snare.sh was being skipped when `cfg.WebhookURL` was empty. This is wrong — revocation authenticates using the device secret and device ID, not the webhook URL.

Users who set up snare without a local webhook (relying on the global snare.sh fallback) would leave stale token registrations on the server when disarming.

Removes the `cfg.WebhookURL != ""` guard from both revocation call sites.