### PR TITLE
docs: add Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ The Boto3 user agent tells you which SDK fired it. The ASN tells you it came fro
 curl -fsSL https://snare.sh/install | sh
 ```
 
+Or with Homebrew:
+
+```sh
+brew install peg/tap/snare
+```
+
 Or download a binary from [releases](https://github.com/peg/snare/releases).
 
 Requires Linux or macOS. No other dependencies.


### PR DESCRIPTION
Adds `brew install peg/tap/snare` as a second install option in the README, right after the curl one-liner.

The tap is live at https://github.com/peg/homebrew-tap with support for darwin/amd64, darwin/arm64, linux/amd64, and linux/arm64.