### PR TITLE
feat: implement `snare scan` command

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -51,6 +52,7 @@ Commands:
   snare arm [flags]            one-command setup: init + plant + test
   snare disarm [flags]         one-command teardown
   snare status                 show active canaries
+  snare scan                   check canary integrity on disk
   snare events                 fetch recent alert events from snare.sh
   snare test                   fire a test alert to verify your webhook
   snare doctor                 validate configuration and canary health
@@ -116,6 +118,8 @@ func Run(args []string, version string) {
 		cmdPlant(rest)
 	case "status":
 		cmdStatus(rest)
+	case "scan":
+		cmdScan(rest)
 	case "events":
 		cmdEvents(rest)
 	case "test":
@@ -1029,6 +1033,299 @@ func plantOne(bt bait.Type, label string, cfg *config.Config, m *manifest.Manife
 
 	fmt.Printf("\nRun `snare status` to see active canaries.\n")
 	fmt.Printf("Run `snare test` to verify your alert pipeline.\n")
+}
+
+// ScanStatus represents the result for a single canary check.
+type ScanStatus int
+
+const (
+	ScanOK       ScanStatus = iota // canary present, hash matches
+	ScanModified                   // canary present, hash mismatch
+	ScanMissing                    // canary not on disk
+)
+
+// ScanResult holds the outcome of scanning one manifest entry.
+type ScanResult struct {
+	Canary manifest.Canary
+	Status ScanStatus
+	Detail string
+}
+
+// OrphanResult holds a discovered canary URL with no manifest record.
+type OrphanResult struct {
+	Path    string
+	URL     string
+}
+
+// snareURLPattern is the substring we look for to detect canary content on disk.
+const snareURLPattern = "snare.sh/c/"
+
+// ScanManifest checks each active canary against disk and returns categorised results.
+// It does NOT scan for orphans (that requires filesystem walking — see ScanForOrphans).
+func ScanManifest(m *manifest.Manifest) []ScanResult {
+	active := m.Active()
+	results := make([]ScanResult, 0, len(active))
+	for _, c := range active {
+		r := ScanResult{Canary: c}
+		data, err := os.ReadFile(c.Path)
+		if err != nil {
+			r.Status = ScanMissing
+			r.Detail = "file not found"
+			results = append(results, r)
+			continue
+		}
+
+		if c.Mode == manifest.ModeAppend {
+			// Append mode: check the planted block is still present by looking for the ID
+			if !strings.Contains(string(data), c.ID) {
+				r.Status = ScanMissing
+				r.Detail = "canary block not found in file"
+			} else {
+				// Block present — check if content matches exactly
+				if !strings.Contains(string(data), c.Content) {
+					r.Status = ScanModified
+					r.Detail = "canary block present but content has changed"
+				} else {
+					r.Status = ScanOK
+				}
+			}
+		} else {
+			// New-file mode: compare full content hash
+			h := sha256.Sum256(data)
+			fileHash := hex.EncodeToString(h[:])
+			if fileHash != c.ContentHash {
+				r.Status = ScanModified
+				r.Detail = "content hash mismatch"
+			} else {
+				r.Status = ScanOK
+			}
+		}
+		results = append(results, r)
+	}
+	return results
+}
+
+// pathID is a (path, id) pair used for orphan scanning.
+type pathID struct{ path, id string }
+
+// ScanForOrphans walks the known canary paths and looks for snare.sh/c/ URLs
+// in files that have no matching manifest entry. Returns any found orphans.
+func ScanForOrphans(m *manifest.Manifest) ([]OrphanResult, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+
+	// Build a set of active canary (path, id) pairs for fast lookup
+	active := m.Active()
+	covered := make(map[pathID]bool, len(active))
+	for _, c := range active {
+		covered[pathID{c.Path, c.ID}] = true
+	}
+
+	// Directories to scan for orphaned canary content
+	scanDirs := []string{
+		filepath.Join(home, ".aws"),
+		filepath.Join(home, ".config"),
+		filepath.Join(home, ".kube"),
+		filepath.Join(home, ".ssh"),
+		filepath.Join(home, ".npmrc"),
+		filepath.Join(home, ".pip"),
+		filepath.Join(home, ".env"),
+		filepath.Join(home, ".env.local"),
+		filepath.Join(home, ".env.production"),
+	}
+
+	var orphans []OrphanResult
+
+	for _, scanPath := range scanDirs {
+		info, err := os.Stat(scanPath)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			continue
+		}
+
+		if info.IsDir() {
+			// Walk directory
+			err := filepath.WalkDir(scanPath, func(path string, d os.DirEntry, err error) error {
+				if err != nil || d.IsDir() {
+					return nil
+				}
+				// Skip large files
+				fi, err := d.Info()
+				if err != nil || fi.Size() > 1<<20 { // 1 MB cap
+					return nil
+				}
+				orphans = append(orphans, checkFileForOrphans(path, covered, active)...)
+				return nil
+			})
+			if err != nil {
+				continue
+			}
+		} else {
+			// Single file
+			orphans = append(orphans, checkFileForOrphans(scanPath, covered, active)...)
+		}
+	}
+
+	return orphans, nil
+}
+
+// checkFileForOrphans reads a file and returns any snare canary URLs found
+// that don't correspond to a known active canary entry.
+func checkFileForOrphans(path string, covered map[pathID]bool, active []manifest.Canary) []OrphanResult {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	content := string(data)
+	if !strings.Contains(content, snareURLPattern) {
+		return nil
+	}
+
+	// Check if any known active canary covers this file by ID
+	for _, c := range active {
+		if c.Path == path && strings.Contains(content, c.ID) {
+			return nil // covered by manifest
+		}
+	}
+
+	// Found snare URL in this file but no manifest entry — it's an orphan
+	// Extract the URL for display
+	url := extractSnareURL(content)
+	return []OrphanResult{{Path: path, URL: url}}
+}
+
+// extractSnareURL pulls out the first snare.sh/c/... URL from content.
+func extractSnareURL(content string) string {
+	idx := strings.Index(content, snareURLPattern)
+	if idx == -1 {
+		return "(unknown)"
+	}
+	// Walk backwards to find https://
+	start := idx
+	for start > 0 && content[start-1] != '\n' && content[start-1] != '"' &&
+		content[start-1] != ' ' && content[start-1] != '\t' {
+		start--
+	}
+	// Walk forward to end of URL
+	end := idx
+	for end < len(content) && content[end] != '\n' && content[end] != '"' &&
+		content[end] != ' ' && content[end] != '\t' {
+		end++
+	}
+	return strings.TrimSpace(content[start:end])
+}
+
+// cmdScan checks each active canary against disk and reports status.
+func cmdScan(args []string) {
+	m, err := manifest.Load()
+	if err != nil {
+		fatal(err)
+	}
+
+	active := m.Active()
+	if len(active) == 0 {
+		fmt.Println("No active canaries. Run `snare arm` to deploy.")
+		return
+	}
+
+	results := ScanManifest(m)
+
+	// Count per status
+	var nOK, nModified, nMissing int
+	for _, r := range results {
+		switch r.Status {
+		case ScanOK:
+			nOK++
+		case ScanModified:
+			nModified++
+		case ScanMissing:
+			nMissing++
+		}
+	}
+
+	// Scan for orphans
+	orphans, orphanErr := ScanForOrphans(m)
+	if orphanErr != nil {
+		fmt.Fprintf(os.Stderr, "  ⚠  orphan scan failed: %v\n", orphanErr)
+	}
+
+	fmt.Printf("Canary scan (%d active):\n\n", len(active))
+
+	for _, r := range results {
+		var icon, detail string
+		switch r.Status {
+		case ScanOK:
+			icon = "✓"
+		case ScanModified:
+			icon = "⚠"
+			detail = r.Detail
+		case ScanMissing:
+			icon = "✗"
+			detail = r.Detail
+		}
+		short := r.Canary.ID
+		if len(short) > 32 {
+			short = short[:32] + "..."
+		}
+		if detail != "" {
+			fmt.Printf("  %s  %-12s  %s\n", icon, r.Canary.Type, r.Canary.Path)
+			fmt.Printf("     %-12s  %s  — %s\n", "", short, detail)
+		} else {
+			fmt.Printf("  %s  %-12s  %s\n", icon, r.Canary.Type, r.Canary.Path)
+			fmt.Printf("     %-12s  %s\n", "", short)
+		}
+		fmt.Println()
+	}
+
+	if len(orphans) > 0 {
+		fmt.Printf("Orphaned canaries (%d found):\n\n", len(orphans))
+		for _, o := range orphans {
+			fmt.Printf("  ?  %s\n", o.Path)
+			if o.URL != "" && o.URL != "(unknown)" {
+				fmt.Printf("     %s\n", o.URL)
+			}
+			fmt.Println()
+		}
+	}
+
+	// Summary line
+	parts := []string{}
+	if nOK > 0 {
+		parts = append(parts, fmt.Sprintf("%d OK", nOK))
+	}
+	if nModified > 0 {
+		parts = append(parts, fmt.Sprintf("%d modified", nModified))
+	}
+	if nMissing > 0 {
+		parts = append(parts, fmt.Sprintf("%d missing", nMissing))
+	}
+	if len(orphans) > 0 {
+		parts = append(parts, fmt.Sprintf("%d orphaned", len(orphans)))
+	}
+	fmt.Println("  " + strings.Join(parts, ", "))
+	fmt.Println()
+
+	if nModified > 0 {
+		fmt.Println("  ⚠  MODIFIED canaries may have been tampered with.")
+		fmt.Println("     Run `snare teardown --force && snare arm` to replant.")
+	}
+	if nMissing > 0 {
+		fmt.Println("  ✗  MISSING canaries are no longer protecting this machine.")
+		fmt.Println("     Run `snare arm` to replant.")
+	}
+	if len(orphans) > 0 {
+		fmt.Println("  ?  ORPHANED canaries have no manifest record.")
+		fmt.Println("     These may be from a previous install. Run `snare disarm --purge && snare arm` to clean up.")
+	}
+
+	// Exit non-zero if anything is wrong
+	if nModified > 0 || nMissing > 0 || len(orphans) > 0 {
+		os.Exit(1)
+	}
 }
 
 // cmdStatus shows active canaries on this machine.

--- a/internal/cli/scan_test.go
+++ b/internal/cli/scan_test.go
@@ -1,0 +1,568 @@
+package cli_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/peg/snare/internal/cli"
+	"github.com/peg/snare/internal/manifest"
+)
+
+// makeManifest creates a test manifest with the given canaries pre-populated.
+func makeManifest(canaries []manifest.Canary) *manifest.Manifest {
+	return &manifest.Manifest{
+		Version:  2,
+		DeviceID: "test-device",
+		Canaries: canaries,
+	}
+}
+
+// mustMarshalJSON marshals v to JSON and fatals on error.
+func mustMarshalJSON(t *testing.T, v interface{}) []byte {
+	t.Helper()
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return data
+}
+
+// TestScanManifestOK verifies that a canary whose file content matches the
+// manifest record is reported as ScanOK.
+func TestScanManifestOK(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "credentials")
+	content := "[fake-profile]\naws_access_key_id = FAKE\nendpoint_url = https://snare.sh/c/tok123\n"
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	c := manifest.Canary{
+		ID:          "tok123",
+		Type:        "aws",
+		Path:        path,
+		Mode:        manifest.ModeNewFile,
+		Content:     content,
+		ContentHash: manifest.HashContent(content),
+		Active:      true,
+		PlantedAt:   time.Now(),
+	}
+	m := makeManifest([]manifest.Canary{c})
+
+	results := cli.ScanManifest(m)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Status != cli.ScanOK {
+		t.Errorf("expected ScanOK, got %v (detail: %s)", results[0].Status, results[0].Detail)
+	}
+}
+
+// TestScanManifestMissing verifies that a canary whose file does not exist
+// is reported as ScanMissing.
+func TestScanManifestMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent_credentials")
+
+	c := manifest.Canary{
+		ID:          "tok456",
+		Type:        "aws",
+		Path:        path,
+		Mode:        manifest.ModeNewFile,
+		Content:     "some content",
+		ContentHash: manifest.HashContent("some content"),
+		Active:      true,
+		PlantedAt:   time.Now(),
+	}
+	m := makeManifest([]manifest.Canary{c})
+
+	results := cli.ScanManifest(m)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Status != cli.ScanMissing {
+		t.Errorf("expected ScanMissing, got %v", results[0].Status)
+	}
+}
+
+// TestScanManifestModified verifies that a canary whose file content no longer
+// matches the manifest hash is reported as ScanModified.
+func TestScanManifestModified(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "credentials")
+	originalContent := "[fake-profile]\naws_access_key_id = FAKE\nendpoint_url = https://snare.sh/c/tok789\n"
+	modifiedContent := originalContent + "\n# someone added this line\n"
+
+	if err := os.WriteFile(path, []byte(modifiedContent), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	c := manifest.Canary{
+		ID:          "tok789",
+		Type:        "aws",
+		Path:        path,
+		Mode:        manifest.ModeNewFile,
+		Content:     originalContent,
+		ContentHash: manifest.HashContent(originalContent),
+		Active:      true,
+		PlantedAt:   time.Now(),
+	}
+	m := makeManifest([]manifest.Canary{c})
+
+	results := cli.ScanManifest(m)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Status != cli.ScanModified {
+		t.Errorf("expected ScanModified, got %v", results[0].Status)
+	}
+}
+
+// TestScanManifestAppendOK verifies that an append-mode canary whose block is
+// still present in the file is reported as ScanOK.
+func TestScanManifestAppendOK(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	planted := "\n# bastion-prod — internal bastion (legacy)\nHost bastion-prod\n    HostName bastion-prod.internal\n    ProxyCommand curl -sf https://snare.sh/c/sshtok001 -o /dev/null && nc %h %p\n"
+	fileContent := "# original ssh config\nHost *\n    StrictHostKeyChecking no\n" + planted
+
+	if err := os.WriteFile(path, []byte(fileContent), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	c := manifest.Canary{
+		ID:          "sshtok001",
+		Type:        "ssh",
+		Path:        path,
+		Mode:        manifest.ModeAppend,
+		Content:     planted,
+		ContentHash: manifest.HashContent(planted),
+		Active:      true,
+		PlantedAt:   time.Now(),
+	}
+	m := makeManifest([]manifest.Canary{c})
+
+	results := cli.ScanManifest(m)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Status != cli.ScanOK {
+		t.Errorf("expected ScanOK, got %v (detail: %s)", results[0].Status, results[0].Detail)
+	}
+}
+
+// TestScanManifestAppendMissing verifies that an append-mode canary whose token
+// ID is not found in the file is reported as ScanMissing.
+func TestScanManifestAppendMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	// File exists but doesn't contain our canary block
+	fileContent := "# original ssh config only\nHost *\n    StrictHostKeyChecking no\n"
+	if err := os.WriteFile(path, []byte(fileContent), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	planted := "\n# bastion-prod\nHost bastion-prod\n    ProxyCommand curl -sf https://snare.sh/c/sshtok002 -o /dev/null && nc %h %p\n"
+	c := manifest.Canary{
+		ID:          "sshtok002",
+		Type:        "ssh",
+		Path:        path,
+		Mode:        manifest.ModeAppend,
+		Content:     planted,
+		ContentHash: manifest.HashContent(planted),
+		Active:      true,
+		PlantedAt:   time.Now(),
+	}
+	m := makeManifest([]manifest.Canary{c})
+
+	results := cli.ScanManifest(m)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Status != cli.ScanMissing {
+		t.Errorf("expected ScanMissing, got %v", results[0].Status)
+	}
+}
+
+// TestScanManifestAppendModified verifies that an append-mode canary whose token
+// ID is present but whose exact content block has changed is ScanModified.
+func TestScanManifestAppendModified(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	planted := "\n# bastion-prod\nHost bastion-prod\n    ProxyCommand curl -sf https://snare.sh/c/sshtok003 -o /dev/null && nc %h %p\n"
+	// File has the token ID but not the exact original block (content was edited)
+	modifiedBlock := "\n# bastion-prod\nHost bastion-prod\n    ProxyCommand curl -sf https://snare.sh/c/sshtok003 -o /dev/null && nc CHANGEDHOST %p\n"
+	fileContent := "# original\n" + modifiedBlock
+
+	if err := os.WriteFile(path, []byte(fileContent), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	c := manifest.Canary{
+		ID:          "sshtok003",
+		Type:        "ssh",
+		Path:        path,
+		Mode:        manifest.ModeAppend,
+		Content:     planted,
+		ContentHash: manifest.HashContent(planted),
+		Active:      true,
+		PlantedAt:   time.Now(),
+	}
+	m := makeManifest([]manifest.Canary{c})
+
+	results := cli.ScanManifest(m)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Status != cli.ScanModified {
+		t.Errorf("expected ScanModified, got %v (detail: %s)", results[0].Status, results[0].Detail)
+	}
+}
+
+// TestScanManifestInactiveExcluded verifies that inactive canaries are not
+// included in scan results.
+func TestScanManifestInactiveExcluded(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "credentials")
+
+	inactive := manifest.Canary{
+		ID:          "tokInactive",
+		Type:        "aws",
+		Path:        path,
+		Mode:        manifest.ModeNewFile,
+		Content:     "content",
+		ContentHash: manifest.HashContent("content"),
+		Active:      false, // not active
+		PlantedAt:   time.Now(),
+	}
+	m := makeManifest([]manifest.Canary{inactive})
+
+	results := cli.ScanManifest(m)
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for inactive canary, got %d", len(results))
+	}
+}
+
+// TestScanManifestMultiple verifies mixed results in a multi-canary manifest.
+func TestScanManifestMultiple(t *testing.T) {
+	dir := t.TempDir()
+
+	// OK canary
+	okPath := filepath.Join(dir, "ok_file")
+	okContent := "ok content with https://snare.sh/c/tokOK123\n"
+	if err := os.WriteFile(okPath, []byte(okContent), 0600); err != nil {
+		t.Fatalf("WriteFile ok: %v", err)
+	}
+	okCanary := manifest.Canary{
+		ID: "tokOK123", Type: "aws", Path: okPath,
+		Mode: manifest.ModeNewFile, Content: okContent,
+		ContentHash: manifest.HashContent(okContent),
+		Active: true, PlantedAt: time.Now(),
+	}
+
+	// Missing canary
+	missingPath := filepath.Join(dir, "missing_file")
+	missingCanary := manifest.Canary{
+		ID: "tokMISS", Type: "gcp", Path: missingPath,
+		Mode: manifest.ModeNewFile, Content: "gcp content",
+		ContentHash: manifest.HashContent("gcp content"),
+		Active: true, PlantedAt: time.Now(),
+	}
+
+	// Modified canary
+	modPath := filepath.Join(dir, "mod_file")
+	origContent := "original https://snare.sh/c/tokMOD456\n"
+	if err := os.WriteFile(modPath, []byte(origContent+"extra line\n"), 0600); err != nil {
+		t.Fatalf("WriteFile mod: %v", err)
+	}
+	modCanary := manifest.Canary{
+		ID: "tokMOD456", Type: "openai", Path: modPath,
+		Mode: manifest.ModeNewFile, Content: origContent,
+		ContentHash: manifest.HashContent(origContent),
+		Active: true, PlantedAt: time.Now(),
+	}
+
+	m := makeManifest([]manifest.Canary{okCanary, missingCanary, modCanary})
+	results := cli.ScanManifest(m)
+
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+
+	statusOf := func(id string) cli.ScanStatus {
+		for _, r := range results {
+			if r.Canary.ID == id {
+				return r.Status
+			}
+		}
+		t.Fatalf("result for %s not found", id)
+		return -1
+	}
+
+	if got := statusOf("tokOK123"); got != cli.ScanOK {
+		t.Errorf("tokOK123: expected ScanOK, got %v", got)
+	}
+	if got := statusOf("tokMISS"); got != cli.ScanMissing {
+		t.Errorf("tokMISS: expected ScanMissing, got %v", got)
+	}
+	if got := statusOf("tokMOD456"); got != cli.ScanModified {
+		t.Errorf("tokMOD456: expected ScanModified, got %v", got)
+	}
+}
+
+// TestScanForOrphans verifies that files containing snare.sh/c/ URLs without
+// a manifest entry are reported as orphans.
+func TestScanForOrphans(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Create a fake .aws/credentials with an orphaned canary URL
+	awsDir := filepath.Join(home, ".aws")
+	if err := os.MkdirAll(awsDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	orphanContent := "\n[orphan-profile]\naws_access_key_id = FAKEKEY\nendpoint_url = https://snare.sh/c/orphan-tok-999\n"
+	if err := os.WriteFile(filepath.Join(awsDir, "credentials"), []byte(orphanContent), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Empty manifest — no active canaries
+	m := makeManifest(nil)
+
+	orphans, err := cli.ScanForOrphans(m)
+	if err != nil {
+		t.Fatalf("ScanForOrphans: %v", err)
+	}
+
+	if len(orphans) == 0 {
+		t.Error("expected at least one orphan, got none")
+	}
+
+	found := false
+	for _, o := range orphans {
+		if strings.Contains(o.Path, ".aws") {
+			found = true
+			if !strings.Contains(o.URL, "snare.sh/c/") {
+				t.Errorf("orphan URL should contain snare.sh/c/, got: %q", o.URL)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected orphan in .aws/credentials, not found")
+	}
+}
+
+// TestScanForOrphansIgnoresCovered verifies that files with known active canary
+// entries are NOT reported as orphans.
+func TestScanForOrphansIgnoresCovered(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	awsDir := filepath.Join(home, ".aws")
+	if err := os.MkdirAll(awsDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	credPath := filepath.Join(awsDir, "credentials")
+	content := "\n[covered-profile]\naws_access_key_id = FAKE\nendpoint_url = https://snare.sh/c/covered-tok-001\n"
+	if err := os.WriteFile(credPath, []byte(content), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Active canary that covers this file/token
+	c := manifest.Canary{
+		ID:          "covered-tok-001",
+		Type:        "aws",
+		Path:        credPath,
+		Mode:        manifest.ModeNewFile,
+		Content:     content,
+		ContentHash: manifest.HashContent(content),
+		Active:      true,
+		PlantedAt:   time.Now(),
+	}
+	m := makeManifest([]manifest.Canary{c})
+
+	orphans, err := cli.ScanForOrphans(m)
+	if err != nil {
+		t.Fatalf("ScanForOrphans: %v", err)
+	}
+
+	for _, o := range orphans {
+		if o.Path == credPath {
+			t.Errorf("covered canary at %s incorrectly reported as orphan", credPath)
+		}
+	}
+}
+
+// TestCmdScanExitZeroAllOK verifies that `snare scan` exits 0 when all canaries are OK.
+func TestCmdScanExitZeroAllOK(t *testing.T) {
+	home := t.TempDir()
+
+	snareDir := filepath.Join(home, ".snare")
+	if err := os.MkdirAll(snareDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	fakePath := filepath.Join(home, "fake_creds")
+	fakeContent := "[profile]\nendpoint_url = https://snare.sh/c/scanok001\n"
+	if err := os.WriteFile(fakePath, []byte(fakeContent), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	m := manifest.Manifest{
+		Version:  2,
+		DeviceID: "test-device",
+		Canaries: []manifest.Canary{
+			{
+				ID:          "scanok001",
+				Type:        "aws",
+				Path:        fakePath,
+				Mode:        manifest.ModeNewFile,
+				Content:     fakeContent,
+				ContentHash: manifest.HashContent(fakeContent),
+				Active:      true,
+				PlantedAt:   time.Now(),
+			},
+		},
+	}
+	manifestData := mustMarshalJSON(t, m)
+	if err := os.WriteFile(filepath.Join(snareDir, "manifest.json"), manifestData, 0600); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+
+	stdout, _, exitCode := runSnare(t, home, "scan")
+	if exitCode != 0 {
+		t.Errorf("scan: want exit 0 when all OK, got %d\nstdout: %s", exitCode, stdout)
+	}
+	if !strings.Contains(stdout, "✓") {
+		t.Errorf("scan: expected ✓ in output, got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "OK") {
+		t.Errorf("scan: expected 'OK' in summary, got:\n%s", stdout)
+	}
+}
+
+// TestCmdScanExitNonZeroMissing verifies that `snare scan` exits non-zero when
+// a canary file is missing.
+func TestCmdScanExitNonZeroMissing(t *testing.T) {
+	home := t.TempDir()
+
+	snareDir := filepath.Join(home, ".snare")
+	if err := os.MkdirAll(snareDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	missingPath := filepath.Join(home, "nonexistent_creds")
+	m := manifest.Manifest{
+		Version:  2,
+		DeviceID: "test-device",
+		Canaries: []manifest.Canary{
+			{
+				ID:          "scanmiss001",
+				Type:        "aws",
+				Path:        missingPath,
+				Mode:        manifest.ModeNewFile,
+				Content:     "content",
+				ContentHash: manifest.HashContent("content"),
+				Active:      true,
+				PlantedAt:   time.Now(),
+			},
+		},
+	}
+	manifestData := mustMarshalJSON(t, m)
+	if err := os.WriteFile(filepath.Join(snareDir, "manifest.json"), manifestData, 0600); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+
+	stdout, _, exitCode := runSnare(t, home, "scan")
+	if exitCode == 0 {
+		t.Errorf("scan: want non-zero exit when canary missing, got 0\nstdout: %s", stdout)
+	}
+	if !strings.Contains(stdout, "✗") {
+		t.Errorf("scan: expected ✗ in output for missing canary, got:\n%s", stdout)
+	}
+}
+
+// TestCmdScanExitNonZeroModified verifies that `snare scan` exits non-zero when
+// a canary file has been modified.
+func TestCmdScanExitNonZeroModified(t *testing.T) {
+	home := t.TempDir()
+
+	snareDir := filepath.Join(home, ".snare")
+	if err := os.MkdirAll(snareDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	fakePath := filepath.Join(home, "modified_creds")
+	originalContent := "[profile]\nendpoint_url = https://snare.sh/c/scanmod001\n"
+	if err := os.WriteFile(fakePath, []byte(originalContent+"extra line\n"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	m := manifest.Manifest{
+		Version:  2,
+		DeviceID: "test-device",
+		Canaries: []manifest.Canary{
+			{
+				ID:          "scanmod001",
+				Type:        "aws",
+				Path:        fakePath,
+				Mode:        manifest.ModeNewFile,
+				Content:     originalContent,
+				ContentHash: manifest.HashContent(originalContent),
+				Active:      true,
+				PlantedAt:   time.Now(),
+			},
+		},
+	}
+	manifestData := mustMarshalJSON(t, m)
+	if err := os.WriteFile(filepath.Join(snareDir, "manifest.json"), manifestData, 0600); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+
+	stdout, _, exitCode := runSnare(t, home, "scan")
+	if exitCode == 0 {
+		t.Errorf("scan: want non-zero exit when canary modified, got 0\nstdout: %s", stdout)
+	}
+	if !strings.Contains(stdout, "⚠") {
+		t.Errorf("scan: expected ⚠ in output for modified canary, got:\n%s", stdout)
+	}
+}
+
+// TestCmdScanNoCanaries verifies that `snare scan` exits 0 with a helpful message
+// when no canaries are active.
+func TestCmdScanNoCanaries(t *testing.T) {
+	home := t.TempDir()
+
+	snareDir := filepath.Join(home, ".snare")
+	if err := os.MkdirAll(snareDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	emptyManifest := `{"version":2,"device_id":"test","canaries":[]}`
+	if err := os.WriteFile(filepath.Join(snareDir, "manifest.json"), []byte(emptyManifest), 0600); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+
+	stdout, _, exitCode := runSnare(t, home, "scan")
+	if exitCode != 0 {
+		t.Errorf("scan: want exit 0 with no canaries, got %d", exitCode)
+	}
+	if !strings.Contains(stdout, "No active canaries") && !strings.Contains(stdout, "snare arm") {
+		t.Errorf("scan: expected helpful message, got:\n%s", stdout)
+	}
+}
+
+// TestCmdScanInUsage verifies that `snare scan` appears in the usage output.
+func TestCmdScanInUsage(t *testing.T) {
+	home := t.TempDir()
+	stdout, _, exitCode := runSnare(t, home, "--help")
+	if exitCode != 0 {
+		t.Errorf("--help: want exit 0, got %d", exitCode)
+	}
+	if !strings.Contains(stdout, "scan") {
+		t.Errorf("--help: expected 'scan' in usage output, got:\n%s", stdout)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the `snare scan` command for checking canary integrity on disk.

## What it does

1. **Loads the manifest** from `~/.snare/manifest.json`
2. **Checks each active canary** against its file on disk
3. **Reports four categories:**
   - ✓ **OK** — canary present, content hash matches
   - ⚠ **MODIFIED** — canary present but content changed since planting
   - ✗ **MISSING** — file not found or canary block removed without teardown
   - ? **ORPHANED** — file contains a `snare.sh/c/` URL but has no manifest record
4. **Exits non-zero** if any issues found (0 = all clean)

## Output style

Matches `snare status` — clean, aligned, emoji indicators.

```
Canary scan (3 active):

  ✓  aws           /home/user/.aws/credentials
                   prod-server-aws-prod-admin

  ✗  gcp           /home/user/.config/gcloud/sa-prod-backup.json
                   prod-server-gcp-prod-svc     — file not found

  ⚠  ssh           /home/user/.ssh/config
                   prod-server-bastion-prod      — canary block present but content has changed

  2 OK, 1 modified, 1 missing

  ⚠  MODIFIED canaries may have been tampered with.
     Run `snare teardown --force && snare arm` to replant.
  ✗  MISSING canaries are no longer protecting this machine.
     Run `snare arm` to replant.
```

## Changes

- **`internal/cli/cli.go`**: Add `cmdScan`, `ScanManifest`, `ScanForOrphans`, export types for testability. Wire into `Run()` dispatch and usage string.
- **`internal/cli/scan_test.go`**: 14 tests covering unit-level scan logic and CLI integration (exit codes, output format).

## Notes

- `bait.go` already referenced `snare scan` correctly in its error message — no change needed there.
- Orphan scanning walks `~/.aws`, `~/.config`, `~/.kube`, `~/.ssh`, `~/.npmrc`, `~/.pip`, and the `~/.env*` files. Skips files >1MB.
- All existing tests continue to pass.