### PR TITLE
feat: make precision mode the default for snare arm

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,26 +65,30 @@ Requires Linux or macOS. No other dependencies.
 snare arm --webhook https://discord.com/api/webhooks/YOUR/WEBHOOK
 ```
 
-That's it. Snare initializes, plants canaries across your credential locations, fires a test alert to confirm the webhook works, and tells you what's armed.
+That's it. Snare initializes, plants the highest-signal canaries, fires a test alert to confirm the webhook works, and tells you what's armed.
+
+By default, `snare arm` uses **precision mode**: only `awsproc`, `ssh`, and `k8s` canaries are planted. These fire only on active credential use — zero false positives from your own tooling.
+
+**Running AI agents on this machine?** The default precision mode won't fire on your own tooling. Use `--all` to arm every canary type.
 
 ```
   ✓ initialized (device: dev-2146102a5849a7b3)
 
   Planting canaries...
-    ✓ aws          ~/.aws/credentials
+  Precision mode: planting highest-signal canaries only (awsproc, ssh, k8s)
     ✓ awsproc      ~/.aws/config
-    ✓ gcp          ~/.config/gcloud/sa-prod-backup.json
-    ✓ openai       ~/.env
-    ✓ anthropic    ~/.env.local
     ✓ ssh          ~/.ssh/config
     ✓ k8s          ~/.kube/staging-deploy.yaml
-    ✓ npm          ~/.npmrc
-    ✓ mcp          ~/.config/mcp-servers-backup.json
-    ✓ pypi         ~/.config/pip/pip.conf
 
   ✓ webhook test fired
 
-  🪤 10 canaries armed. This machine is protected.
+  🪤 3 canaries armed. This machine is protected.
+```
+
+To arm all canary types (including dotenv-based ones like OpenAI, Anthropic, etc.):
+
+```sh
+snare arm --all --webhook https://discord.com/api/webhooks/YOUR/WEBHOOK
 ```
 
 Supported webhook destinations: Discord, Slack, Telegram, PagerDuty, MS Teams.
@@ -180,13 +184,7 @@ Canarytokens can't do this. Their AWS canary creates a real IAM user and monitor
 
 On airgapped or firewalled machines: even if the callback can't reach snare.sh, the shell command still returns fake credential JSON. The agent gets apparently-valid creds and keeps going. If it later tries to use them from outside your network, that fires separately.
 
-If you want near-zero false positives and only the highest-signal canaries:
-
-```sh
-snare arm --precision --webhook <url>
-# Plants: awsproc, ssh, k8s
-# Skips: dotenv-based canaries that fire conditionally
-```
+This is why `awsproc`, `ssh`, and `k8s` are planted by default — they fire only on active credential use, making them the best choice for machines running AI agents.
 
 ### mcp
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -46,7 +46,7 @@ func reliability(t string) string {
 const usage = `snare — compromise detection for AI agents via deception
 
 Quick start:
-  snare arm --webhook <url>    arm this machine (init + plant all + test)
+  snare arm --webhook <url>    arm this machine (init + plant precision canaries + test)
   snare disarm                 remove all canaries and clean up
   snare status                 show active canaries
 
@@ -72,8 +72,8 @@ Advanced:
 Flags (arm):
   --webhook <url>              webhook URL (Discord, Slack, Telegram, or custom)
   --label <name>               prefix canary names (defaults to hostname)
-  --precision                  plant only highest-signal canaries (awsproc, ssh, k8s)
-                               near-zero false positives; fires only on active credential use
+  --all                        plant all canary types including dotenv-based ones
+                               (openai, anthropic, huggingface, npm, mcp, github, stripe, generic, docker, azure)
   --dry-run                    show what would be planted without writing
 
 Flags (plant):
@@ -159,22 +159,27 @@ var precisionTypes = []bait.Type{
 
 func cmdArm(args []string) {
 	if hasFlag(args, "--help") || hasFlag(args, "-h") {
-		fmt.Print(`snare arm — initialize snare and plant all recommended canaries
+		fmt.Print(`snare arm — initialize snare and plant canaries (precision mode by default)
 
 Usage:
   snare arm [flags]
 
+By default, snare arm plants only the highest-signal canaries (awsproc, ssh, k8s).
+These fire only on active credential use — zero false positives from your own tooling.
+Running AI agents on this machine? The default precision mode won't fire on your own tooling.
+Use --all to arm every canary type.
+
 Flags:
   --webhook <url>    webhook URL (Discord, Slack, Telegram, PagerDuty, Teams)
   --label <name>     prefix canary names (defaults to hostname)
-  --precision        plant only awsproc, ssh, k8s (near-zero false positives)
+  --all              plant all canary types including dotenv-based ones
   --dry-run          show what would be planted without writing anything
   --help             show this help
 
 Examples:
   snare arm --webhook https://discord.com/api/webhooks/...
   snare arm --webhook https://hooks.slack.com/... --label prod-server
-  snare arm --precision --webhook <url>
+  snare arm --all --webhook <url>
 `)
 		return
 	}
@@ -182,7 +187,7 @@ Examples:
 	webhookURL := flagValue(args, "--webhook")
 	label      := flagValue(args, "--label")
 	dryRun     := hasFlag(args, "--dry-run")
-	precision  := hasFlag(args, "--precision")
+	armAll     := hasFlag(args, "--all")
 
 	if label == "" {
 		if h, err := os.Hostname(); err == nil {
@@ -251,9 +256,11 @@ Examples:
 	fmt.Println()
 	fmt.Println("  Planting canaries...")
 
-	armTypes := highReliabilityTypes
-	if precision {
-		armTypes = precisionTypes
+	armTypes := precisionTypes
+	if armAll {
+		armTypes = highReliabilityTypes
+		fmt.Println("  Full mode: planting all canary types (including dotenv-based)")
+	} else {
 		fmt.Println("  Precision mode: planting highest-signal canaries only (awsproc, ssh, k8s)")
 	}
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -116,8 +116,8 @@ func TestCmdArmHelp(t *testing.T) {
 	if !strings.Contains(stdout, "--webhook") {
 		t.Errorf("arm --help: expected '--webhook' in output, got:\n%s", stdout)
 	}
-	if !strings.Contains(stdout, "--precision") {
-		t.Errorf("arm --help: expected '--precision' in output, got:\n%s", stdout)
+	if !strings.Contains(stdout, "--all") {
+		t.Errorf("arm --help: expected '--all' in output, got:\n%s", stdout)
 	}
 
 	// Verify no config was written
@@ -261,25 +261,24 @@ func TestRegisterTokenErrorBody(t *testing.T) {
 	}
 }
 
-// TestPrecisionMode verifies that --precision flag selects only awsproc, ssh, k8s
-// canary types. We test this by checking that precisionTypes matches expectations
-// via the exported behavior of bait.Type constants.
-func TestPrecisionMode(t *testing.T) {
-	// Expected precision types per the CLI implementation
+// TestDefaultPrecisionMode verifies that the default arm behavior selects only
+// awsproc, ssh, k8s (precision mode). The full set is opt-in via --all.
+func TestDefaultPrecisionMode(t *testing.T) {
+	// Expected default (precision) types
 	wantTypes := map[bait.Type]bool{
 		bait.TypeAWSProc: true,
 		bait.TypeSSH:     true,
 		bait.TypeK8s:     true,
 	}
 
-	// Verify the precision types are distinct from full arm types
+	// Types present in --all but not in default
 	allTypes := []bait.Type{
 		bait.TypeAWS, bait.TypeAWSProc, bait.TypeGCP,
 		bait.TypeSSH, bait.TypeK8s, bait.TypePyPI,
 		bait.TypeOpenAI, bait.TypeAnthropic, bait.TypeNPM, bait.TypeMCP,
 	}
 
-	// Count types that would NOT be planted under --precision
+	// Default (precision) set excludes non-high-signal types
 	excluded := 0
 	for _, bt := range allTypes {
 		if !wantTypes[bt] {
@@ -287,32 +286,32 @@ func TestPrecisionMode(t *testing.T) {
 		}
 	}
 	if excluded == 0 {
-		t.Error("precision mode should exclude at least some types from the full arm set")
+		t.Error("default precision mode should exclude at least some types from the full set")
 	}
 
-	// Precision set should have exactly 3 types
+	// Default set should have exactly 3 types
 	if len(wantTypes) != 3 {
-		t.Errorf("precision mode: expected 3 types, definition has %d", len(wantTypes))
+		t.Errorf("default precision mode: expected 3 types, got %d", len(wantTypes))
 	}
 
-	// Verify precision types are the highest-signal ones
+	// Verify the right 3 types are included
 	for _, bt := range []bait.Type{bait.TypeAWSProc, bait.TypeSSH, bait.TypeK8s} {
 		if !wantTypes[bt] {
-			t.Errorf("precision mode: expected %s to be in precision set", bt)
+			t.Errorf("default precision mode: expected %s to be included", bt)
 		}
 	}
 
-	// Verify lower-signal types are NOT in precision set
+	// Verify lower-signal types are excluded by default
 	for _, bt := range []bait.Type{bait.TypeAWS, bait.TypeGCP, bait.TypeOpenAI, bait.TypeNPM} {
 		if wantTypes[bt] {
-			t.Errorf("precision mode: expected %s to be excluded (lower signal)", bt)
+			t.Errorf("default precision mode: expected %s to be excluded", bt)
 		}
 	}
 }
 
-// TestPrecisionModeOutput verifies that `snare arm --precision --dry-run` output
-// only mentions awsproc, ssh, and k8s — not aws, gcp, openai, etc.
-func TestPrecisionModeOutput(t *testing.T) {
+// TestDefaultArmOutput verifies that `snare arm --dry-run` (no flags) uses precision
+// mode by default and only mentions awsproc, ssh, and k8s — not aws, gcp, openai, etc.
+func TestDefaultArmOutput(t *testing.T) {
 	home := t.TempDir()
 
 	// Pre-initialize config to avoid interactive prompts
@@ -336,23 +335,56 @@ func TestPrecisionModeOutput(t *testing.T) {
 		t.Fatalf("WriteFile manifest: %v", err)
 	}
 
-	stdout, _, _ := runSnare(t, home, "arm", "--precision", "--dry-run")
+	stdout, _, _ := runSnare(t, home, "arm", "--dry-run")
 
-	// Should mention precision mode
+	// Should mention precision mode (default behavior)
 	if !strings.Contains(stdout, "precision") && !strings.Contains(strings.ToLower(stdout), "awsproc") {
-		t.Logf("arm --precision --dry-run output:\n%s", stdout)
-		t.Error("expected precision mode output to mention awsproc or precision")
+		t.Logf("arm --dry-run output:\n%s", stdout)
+		t.Error("expected default arm output to mention awsproc or precision")
 	}
 
 	// Should NOT plant full set types like gcp, openai
 	if strings.Contains(stdout, "→") || strings.Contains(stdout, "would plant") {
 		// dry-run output present — check it doesn't include non-precision types
 		if strings.Contains(stdout, "openai") {
-			t.Error("precision mode output mentioned openai — should be excluded")
+			t.Error("default arm output mentioned openai — should be excluded (use --all)")
 		}
 		if strings.Contains(stdout, " gcp ") {
-			t.Error("precision mode output mentioned gcp — should be excluded")
+			t.Error("default arm output mentioned gcp — should be excluded (use --all)")
 		}
+	}
+}
+
+// TestAllFlagOutput verifies that `snare arm --all --dry-run` includes the full
+// canary set (gcp, openai, etc.) and mentions "Full mode".
+func TestAllFlagOutput(t *testing.T) {
+	home := t.TempDir()
+
+	snareDir := filepath.Join(home, ".snare")
+	if err := os.MkdirAll(snareDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	cfg := map[string]string{
+		"device_id":     "dev-all-test",
+		"device_secret": "deadbeefdeadbeefdeadbeefdeadbeef",
+		"callback_base": "https://snare.sh/c",
+		"webhook_url":   "https://hooks.example.com/test",
+	}
+	data, _ := json.MarshalIndent(cfg, "", "  ")
+	if err := os.WriteFile(filepath.Join(snareDir, "config.json"), data, 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	emptyManifest := `{"canaries":[]}`
+	if err := os.WriteFile(filepath.Join(snareDir, "manifest.json"), []byte(emptyManifest), 0600); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+
+	stdout, _, _ := runSnare(t, home, "arm", "--all", "--dry-run")
+
+	// Should mention full mode
+	if !strings.Contains(strings.ToLower(stdout), "full mode") && !strings.Contains(strings.ToLower(stdout), "all canary") {
+		t.Logf("arm --all --dry-run output:\n%s", stdout)
+		t.Error("expected --all output to mention full mode or all canary types")
 	}
 }
 


### PR DESCRIPTION
## Summary

Flips the default behavior of `snare arm`: precision mode (awsproc, ssh, k8s only) is now the default. The full canary set is opt-in via `--all`.

## Rationale

Snare is built for developers running AI agents. Dotenv canaries fire whenever any agent loads `~/.env`, causing false positives for the primary user base. Precision canaries (awsproc, ssh, k8s) fire only on active credential use — zero false positives from your own tooling.

## Changes

- `snare arm` with no flags → precision mode (awsproc, ssh, k8s only)
- `snare arm --all` → all canaries including dotenv-based ones (openai, anthropic, huggingface, npm, mcp, github, stripe, generic, docker, azure)
- Removed `--precision` flag (it's now the default; `--all` is the opt-in)
- Updated usage string and help text
- Updated README: added precision-mode-first quick start, note about AI agents, `--all` instructions, removed stale `--precision` example in awsproc section
- Updated tests: replaced `TestPrecisionMode`/`TestPrecisionModeOutput` with `TestDefaultPrecisionMode`, `TestDefaultArmOutput`, and `TestAllFlagOutput`

## Before / After

**Before:**
```
snare arm --webhook <url>       # plants all 13 canary types
snare arm --precision --webhook # plants awsproc, ssh, k8s only
```

**After:**
```
snare arm --webhook <url>       # plants awsproc, ssh, k8s only (precision default)
snare arm --all --webhook <url> # plants all 13 canary types
```

## Tests

All passing: `go test ./... -race -count=1`