### PR TITLE
fix: darwin build — split terminal raw mode into platform files

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 	"syscall"
 	"time"
-	"unsafe"
 
 	"github.com/peg/snare/internal/bait"
 	"github.com/peg/snare/internal/config"
@@ -26,46 +25,6 @@ import (
 	"github.com/peg/snare/internal/serve"
 	"github.com/peg/snare/internal/token"
 )
-
-// termios holds terminal attributes for raw mode.
-type termios struct {
-	Iflag  uint32
-	Oflag  uint32
-	Cflag  uint32
-	Lflag  uint32
-	Cc     [20]uint8
-	Ispeed uint32
-	Ospeed uint32
-}
-
-func makeRaw(fd int) (*termios, error) {
-	var old termios
-	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL,
-		uintptr(fd), syscall.TCGETS, uintptr(unsafe.Pointer(&old))); errno != 0 {
-		return nil, errno
-	}
-	raw := old
-	// Disable echo, canonical mode, signals from input
-	raw.Lflag &^= syscall.ECHO | syscall.ICANON | syscall.ISIG | syscall.IEXTEN
-	raw.Iflag &^= syscall.IXON | syscall.ICRNL | syscall.BRKINT | syscall.INPCK | syscall.ISTRIP
-	raw.Cflag |= syscall.CS8
-	raw.Oflag &^= syscall.OPOST
-	raw.Cc[syscall.VMIN] = 1
-	raw.Cc[syscall.VTIME] = 0
-	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL,
-		uintptr(fd), syscall.TCSETS, uintptr(unsafe.Pointer(&raw))); errno != 0 {
-		return nil, errno
-	}
-	return &old, nil
-}
-
-func restoreTerminal(fd int, old *termios) {
-	if old == nil {
-		return
-	}
-	syscall.Syscall(syscall.SYS_IOCTL, //nolint:errcheck
-		uintptr(fd), syscall.TCSETS, uintptr(unsafe.Pointer(old)))
-}
 
 // reliability returns a human-readable reliability label per canary type.
 //

--- a/internal/cli/terminal_darwin.go
+++ b/internal/cli/terminal_darwin.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// termios holds terminal attributes for raw mode (macOS/BSD layout).
+type termios struct {
+	Iflag  uint64
+	Oflag  uint64
+	Cflag  uint64
+	Lflag  uint64
+	Cc     [20]uint8
+	Ispeed uint64
+	Ospeed uint64
+}
+
+const (
+	darwinTIOCGETA = 0x402c7413
+	darwinTIOCSETA = 0x802c7414
+)
+
+func makeRaw(fd int) (*termios, error) {
+	var old termios
+	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL,
+		uintptr(fd), darwinTIOCGETA, uintptr(unsafe.Pointer(&old))); errno != 0 {
+		return nil, errno
+	}
+	raw := old
+	raw.Lflag &^= syscall.ECHO | syscall.ICANON | syscall.ISIG | syscall.IEXTEN
+	raw.Iflag &^= syscall.IXON | syscall.ICRNL | syscall.BRKINT | syscall.INPCK | syscall.ISTRIP
+	raw.Cflag |= syscall.CS8
+	raw.Oflag &^= syscall.OPOST
+	raw.Cc[syscall.VMIN] = 1
+	raw.Cc[syscall.VTIME] = 0
+	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL,
+		uintptr(fd), darwinTIOCSETA, uintptr(unsafe.Pointer(&raw))); errno != 0 {
+		return nil, errno
+	}
+	return &old, nil
+}
+
+func restoreTerminal(fd int, old *termios) {
+	if old == nil {
+		return
+	}
+	syscall.Syscall(syscall.SYS_IOCTL, //nolint:errcheck
+		uintptr(fd), darwinTIOCSETA, uintptr(unsafe.Pointer(old)))
+}

--- a/internal/cli/terminal_linux.go
+++ b/internal/cli/terminal_linux.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// termios holds terminal attributes for raw mode.
+type termios struct {
+	Iflag  uint32
+	Oflag  uint32
+	Cflag  uint32
+	Lflag  uint32
+	Cc     [20]uint8
+	Ispeed uint32
+	Ospeed uint32
+}
+
+func makeRaw(fd int) (*termios, error) {
+	var old termios
+	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL,
+		uintptr(fd), syscall.TCGETS, uintptr(unsafe.Pointer(&old))); errno != 0 {
+		return nil, errno
+	}
+	raw := old
+	raw.Lflag &^= syscall.ECHO | syscall.ICANON | syscall.ISIG | syscall.IEXTEN
+	raw.Iflag &^= syscall.IXON | syscall.ICRNL | syscall.BRKINT | syscall.INPCK | syscall.ISTRIP
+	raw.Cflag |= syscall.CS8
+	raw.Oflag &^= syscall.OPOST
+	raw.Cc[syscall.VMIN] = 1
+	raw.Cc[syscall.VTIME] = 0
+	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL,
+		uintptr(fd), syscall.TCSETS, uintptr(unsafe.Pointer(&raw))); errno != 0 {
+		return nil, errno
+	}
+	return &old, nil
+}
+
+func restoreTerminal(fd int, old *termios) {
+	if old == nil {
+		return
+	}
+	syscall.Syscall(syscall.SYS_IOCTL, //nolint:errcheck
+		uintptr(fd), syscall.TCSETS, uintptr(unsafe.Pointer(old)))
+}

--- a/internal/cli/terminal_other.go
+++ b/internal/cli/terminal_other.go
@@ -1,0 +1,14 @@
+//go:build !linux && !darwin
+
+package cli
+
+import "fmt"
+
+// termios is a stub for unsupported platforms.
+type termios struct{}
+
+func makeRaw(_ int) (*termios, error) {
+	return nil, fmt.Errorf("--select requires a Linux or macOS terminal")
+}
+
+func restoreTerminal(_ int, _ *termios) {}


### PR DESCRIPTION
CI failed on darwin/amd64 and darwin/arm64: `syscall.TCGETS`/`TCSETS` are Linux-only constants.

Split terminal raw mode into platform-specific files:
- `terminal_linux.go` — uses `TCGETS`/`TCSETS`
- `terminal_darwin.go` — uses `TIOCGETA`/`TIOCSETA`  
- `terminal_other.go` — stub returning an error for unsupported platforms

Verified: `go build` passes on linux/amd64, darwin/amd64, darwin/arm64.