### PR TITLE
fix: do not fire webhook for unregistered tokens (#23)

### DIFF
--- a/internal/serve/handlers.go
+++ b/internal/serve/handlers.go
@@ -81,9 +81,16 @@ func (s *Server) processAlert(token, ip, ua, method, path, timestamp string, isT
 		log.Printf("get token error: %v", err)
 	}
 
+	// Unregistered tokens never fire webhooks — avoids false alerts from
+	// probe traffic hitting random/partial token URLs.
+	if reg == nil {
+		log.Printf("UNREGISTERED token=%s — skipping webhook", token)
+		return
+	}
+
 	// Determine webhook target
 	webhookURL := s.cfg.WebhookURL // global fallback
-	if reg != nil && reg.WebhookURL != "" && reg.WebhookURL != "use-global" {
+	if reg.WebhookURL != "" && reg.WebhookURL != "use-global" {
 		webhookURL = reg.WebhookURL
 	}
 


### PR DESCRIPTION
Fixes #23.

In `processAlert`, when `db.getToken` returns `nil` (token not registered), the global fallback webhook was still fired. This caused false alerts from probe traffic hitting partial/random token URLs.

**Fix:** early return after inserting the event if `reg == nil`. Event is still recorded for audit, but no webhook fires.

```go
if reg == nil {
    log.Printf("CANARY_UNREGISTERED token=%s ip=%s — no webhook fired", token, ip)
    return
}
```