### PR TITLE
ci: sign release checksums with Sigstore/cosign (#21)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -23,6 +24,9 @@ jobs:
 
       - name: Run tests
         run: go test ./... -race -count=1
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
 
       - name: Build binaries
         run: |
@@ -51,11 +55,15 @@ jobs:
           echo "=== checksums.txt ==="
           cat dist/checksums.txt
 
+      - name: Sign checksums with cosign
+        run: cosign sign-blob --yes dist/checksums.txt --bundle dist/checksums.txt.bundle
+
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
             dist/*.tar.gz
             dist/checksums.txt
+            dist/checksums.txt.bundle
           generate_release_notes: true
           fail_on_unmatched_files: false

--- a/README.md
+++ b/README.md
@@ -270,6 +270,18 @@ To point canaries at your own server instead of snare.sh, edit `callback_base` i
 
 ---
 
+## Verifying releases
+
+Release checksums are signed with [Sigstore/cosign](https://docs.sigstore.dev/) using keyless OIDC signing via GitHub Actions. To verify a downloaded release:
+
+```sh
+cosign verify-blob --bundle checksums.txt.bundle checksums.txt
+```
+
+This confirms the checksums file was produced by the official GitHub Actions release workflow and has not been tampered with.
+
+---
+
 ## License
 
 Apache 2.0 — see [LICENSE](./LICENSE).


### PR DESCRIPTION
Fixes #21.

Added keyless Sigstore signing to the release workflow:
- Installs `sigstore/cosign-installer@v3`
- Signs `checksums.txt` after build: `cosign sign-blob --yes`
- Uploads `checksums.txt.bundle` as a release asset

Updated README with a "Verifying releases" section:
```bash
cosign verify-blob --bundle checksums.txt.bundle checksums.txt
```