### PR TITLE
fix: polish v0.2.0 release foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,16 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: worker/package-lock.json
+
+      - name: Install worker deps
+        working-directory: worker
+        run: npm ci
+
       - name: Build
         run: go build ./...
 
@@ -26,6 +36,10 @@ jobs:
 
       - name: Test
         run: go test ./... -v -race -count=1
+
+      - name: Test worker
+        working-directory: worker
+        run: npm test
 
       - name: staticcheck
         uses: dominikh/staticcheck-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ Versioning: [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-01
+
+### Added
+- `snare serve --trusted-proxy <cidr,...>` so self-hosted deployments only trust `X-Forwarded-For` / `X-Real-IP` from explicitly configured reverse proxies
+- Server-side `/api/rotate` endpoint and safer `snare rotate` flow that updates the hosted secret before replacing the local secret
+- Device ownership on stored events, preserving event access for revoked tokens without opening reads to unrelated devices
+- CI coverage for worker tests, plus additional canary inventory, rotation, and serve/event tests
+
+### Changed
+- `snare arm --all` and `snare plant --all` now use one canonical list of all 18 implemented canary types, including `git`, `terraform`, and `generic`
+- Alert copy and privacy docs now say the precise guarantee: IP, user agent, timestamp, method/path, and coarse network metadata only — no request body inspection
+- Webhook guidance now treats webhook URLs as secrets and documents custom JSON endpoints
+
+### Fixed
+- Worker and self-hosted webhook logs no longer print raw canary token IDs or webhook URLs on common failure paths
+- Worker authentication no longer silently auto-registers unknown devices during authenticated API requests
+- Docker registry generation returns errors instead of panicking on `crypto/rand` failure
+- Self-hosted callback IP attribution no longer trusts spoofable proxy headers by default
+- Discord/Slack alert metadata includes the full canary inventory labels for newer canary types
+
 ## [0.1.4] - 2026-03-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The agent sees a flaky AWS response. You see this:
 
 ```
 🔑 AWS canary fired — agent-01
-Token   agent-01-••••••••••••••••
+Token   agent-prod-admin-2026-••••••••
 Time    2026-03-14 04:07:33 UTC
 IP      34.121.8.92       Location  Council Bluffs, US
 Network Amazon Technologies Inc (AS16509)
@@ -94,7 +94,7 @@ To arm all canary types (including dotenv-based ones like OpenAI, Anthropic, etc
 snare arm --all --webhook https://discord.com/api/webhooks/YOUR/WEBHOOK
 ```
 
-Supported webhook destinations: Discord, Slack, Telegram, PagerDuty, MS Teams.
+Supported webhook destinations: Discord, Slack, Telegram, or any endpoint that accepts JSON. Treat webhook URLs as secrets — don't commit, screenshot, or share them.
 
 ---
 
@@ -220,7 +220,7 @@ Alerts are signed with `X-Snare-Signature` (HMAC-SHA256) so you can verify they 
 
 ## Privacy
 
-Snare never reads request bodies. When a canary fires, the worker returns a response before the body is consumed. Canary callbacks can carry real credentials or prompts in their body — we never see them.
+Snare's callback handlers never read request bodies. When a canary fires, the worker returns a response before the body is consumed. Canary callbacks can carry real credentials or prompts in their body — the application code does not inspect them. In managed mode, Cloudflare still terminates the network request; self-host if you need full network-layer control.
 
 Each alert stores only: token ID, timestamp, IP, user agent, method, path, country, ASN.
 
@@ -271,7 +271,7 @@ To point canaries at your own server instead of snare.sh, edit `callback_base` i
 
 `snare serve` requires `--dashboard-token` (or `SNARE_DASHBOARD_TOKEN`) to protect the dashboard. Generate one with `openssl rand -hex 32`.
 
-> **Important:** Only expose `snare serve` behind a reverse proxy you control (nginx, Caddy, Cloudflare Tunnel). Never bind directly to a public interface. The server trusts `X-Forwarded-For` headers for IP attribution, which can be spoofed without a trusted upstream.
+> **Important:** Only expose `snare serve` behind a reverse proxy you control (nginx, Caddy, Cloudflare Tunnel). Never bind directly to a public interface. By default the server ignores `X-Forwarded-For` and `X-Real-IP`. If you want real client IP attribution behind a trusted proxy, set `--trusted-proxy <cidr,...>` to the proxy network(s) that are allowed to supply those headers.
 
 ---
 

--- a/internal/cli/canary_inventory_test.go
+++ b/internal/cli/canary_inventory_test.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/peg/snare/internal/bait"
+)
+
+func TestAllCanaryTypesMatchesImplementedInventory(t *testing.T) {
+	want := []bait.Type{
+		bait.TypeAWSProc,
+		bait.TypeSSH,
+		bait.TypeK8s,
+		bait.TypeAWS,
+		bait.TypeGCP,
+		bait.TypeNPM,
+		bait.TypeGit,
+		bait.TypePyPI,
+		bait.TypeAzure,
+		bait.TypeOpenAI,
+		bait.TypeAnthropic,
+		bait.TypeMCP,
+		bait.TypeGitHub,
+		bait.TypeStripe,
+		bait.TypeHuggingFace,
+		bait.TypeDocker,
+		bait.TypeTerraform,
+		bait.TypeGeneric,
+	}
+
+	if len(allCanaryTypes) != len(want) {
+		t.Fatalf("allCanaryTypes has %d entries, want %d", len(allCanaryTypes), len(want))
+	}
+	if len(allSelectEntries) != len(want) {
+		t.Fatalf("allSelectEntries has %d entries, want %d", len(allSelectEntries), len(want))
+	}
+
+	seen := map[bait.Type]bool{}
+	for i, bt := range allCanaryTypes {
+		if bt != want[i] {
+			t.Fatalf("allCanaryTypes[%d] = %s, want %s", i, bt, want[i])
+		}
+		if allSelectEntries[i].t != bt {
+			t.Fatalf("allSelectEntries[%d] = %s, want %s", i, allSelectEntries[i].t, bt)
+		}
+		if seen[bt] {
+			t.Fatalf("duplicate canary type in allCanaryTypes: %s", bt)
+		}
+		seen[bt] = true
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -22,23 +22,24 @@ var httpClient = &http.Client{Timeout: 15 * time.Second}
 // reliability returns a human-readable reliability label per canary type.
 //
 // Tiers:
-//   precision — fires via existing SDK/OS plumbing, no agent hunting needed,
-//               no DNS dependency, zero false positives
-//   high      — fires when credential is actively used, but requires agent to
-//               find and use it, or has a DNS/runtime dependency
-//   medium    — fires conditionally: depends on dotenv loading, base URL
-//               override support, or agent doing explicit credential scanning
+//
+//	precision — fires via existing SDK/OS plumbing, no agent hunting needed,
+//	            no DNS dependency, zero false positives
+//	high      — fires when credential is actively used, but requires agent to
+//	            find and use it, or has a DNS/runtime dependency
+//	medium    — fires conditionally: depends on dotenv loading, base URL
+//	            override support, or agent doing explicit credential scanning
 func reliability(t string) string {
 	switch bait.Type(t) {
 	// Precision: fires via SDK/OS hooks before or during connection, no DNS needed
 	case bait.TypeAWSProc, bait.TypeSSH, bait.TypeK8s:
 		return "precision"
 	// High: fires on active credential use, requires agent to find+use the cred
-	case bait.TypeAWS,   // endpoint_url fires on any AWS SDK call with that profile
-		bait.TypeGCP,    // token_uri fires on GCP SDK auth (needs explicit file load)
-		bait.TypePyPI,   // extra-index-url fires on pip install (own installs too — see warning)
-		bait.TypeNPM,    // scoped registry fires on npm install (scoped packages only)
-		bait.TypeGit:    // credential.helper fires if agent does git credential fill
+	case bait.TypeAWS, // endpoint_url fires on any AWS SDK call with that profile
+		bait.TypeGCP,  // token_uri fires on GCP SDK auth (needs explicit file load)
+		bait.TypePyPI, // extra-index-url fires on pip install (own installs too — see warning)
+		bait.TypeNPM,  // scoped registry fires on npm install (scoped packages only)
+		bait.TypeGit:  // credential.helper fires if agent does git credential fill
 		return "high"
 	// Medium: dotenv-dependent, DNS-dependent, or requires explicit credential scanning
 	default:
@@ -76,13 +77,12 @@ Flags (arm):
   --webhook <url>              webhook URL (Discord, Slack, Telegram, or custom)
   --label <name>               name your canary (e.g. prod-admin-legacy-2024) — defaults to hostname
   --all                        plant all canary types including dotenv-based ones
-                               (openai, anthropic, huggingface, npm, mcp, github, stripe, generic, docker, azure)
   --dry-run                    show what would be planted without writing
 
 Flags (plant):
   --label <name>               name your canary (e.g. prod-admin-legacy-2024) — defaults to hostname
-  --type <type>                canary type: aws, awsproc, gcp, github, stripe, openai, anthropic, ssh, k8s, npm, mcp, pypi, huggingface, docker, azure, generic
-  --all                        plant all high-reliability canary types at once
+  --type <type>                canary type: aws, awsproc, gcp, github, stripe, openai, anthropic, ssh, k8s, npm, mcp, pypi, huggingface, docker, azure, git, terraform, generic
+  --all                        plant all canary types at once
   --dry-run                    show what would be planted without writing anything
 
 Flags (disarm/teardown):
@@ -98,6 +98,7 @@ Flags (serve):
   --webhook-url <url>          global fallback webhook URL for alerts
   --dashboard-token <token>    required: token to protect the dashboard (min 16 chars)
                                also: SNARE_DASHBOARD_TOKEN env var
+  --trusted-proxy <cidr,...>   trust X-Forwarded-For / X-Real-IP only from these proxy CIDRs
 `
 
 // Run dispatches the CLI command.
@@ -340,7 +341,10 @@ func buildParams(bt bait.Type, label string, cfg *config.Config) (bait.Params, e
 		}
 
 	case bait.TypeDocker:
-		p.FakeRegistry = token.NewDockerRegistryName()
+		p.FakeRegistry, err = token.NewDockerRegistryName()
+		if err != nil {
+			return p, err
+		}
 		// FakeToken used as a base64-encoded "auth" value (username:password)
 		// Docker stores base64(user:pass) in the auths section
 		rawToken, err2 := token.NewNPMToken() // reuse a random token format
@@ -464,7 +468,9 @@ func registerToken(cfg *config.Config, tokenID, canaryType, label string) error 
 	if resp.StatusCode >= 400 {
 		body, _ := io.ReadAll(resp.Body)
 		// Try to extract error message from JSON response
-		var errResp struct{ Error string `json:"error"` }
+		var errResp struct {
+			Error string `json:"error"`
+		}
 		if json.Unmarshal(body, &errResp) == nil && errResp.Error != "" {
 			return fmt.Errorf("registration failed: %s", errResp.Error)
 		}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -386,6 +386,35 @@ func TestAllFlagOutput(t *testing.T) {
 		t.Logf("arm --all --dry-run output:\n%s", stdout)
 		t.Error("expected --all output to mention full mode or all canary types")
 	}
+
+	// --all should really mean every implemented canary type, not just the
+	// old high-coverage subset.
+	wantTypes := []bait.Type{
+		bait.TypeAWSProc,
+		bait.TypeSSH,
+		bait.TypeK8s,
+		bait.TypeAWS,
+		bait.TypeGCP,
+		bait.TypeNPM,
+		bait.TypeGit,
+		bait.TypePyPI,
+		bait.TypeAzure,
+		bait.TypeOpenAI,
+		bait.TypeAnthropic,
+		bait.TypeMCP,
+		bait.TypeGitHub,
+		bait.TypeStripe,
+		bait.TypeHuggingFace,
+		bait.TypeDocker,
+		bait.TypeTerraform,
+		bait.TypeGeneric,
+	}
+	for _, bt := range wantTypes {
+		needle := fmt.Sprintf("%s →", bt)
+		if !strings.Contains(stdout, needle) {
+			t.Errorf("arm --all --dry-run missing %s; output:\n%s", bt, stdout)
+		}
+	}
 }
 
 // TestManifestIsolation verifies that tests use t.TempDir() for HOME and that

--- a/internal/cli/cmd_arming.go
+++ b/internal/cli/cmd_arming.go
@@ -29,34 +29,34 @@ var precisionTypes = []bait.Type{
 
 // selectEntry describes one row in the --select TUI.
 type selectEntry struct {
-	t     bait.Type
-	tier  string // "precision", "high", "medium"
-	path  string // short description of where it plants
+	t    bait.Type
+	tier string // "precision", "high", "medium"
+	path string // short description of where it plants
 }
 
 // allSelectEntries is the canonical ordered list for --select mode.
 var allSelectEntries = []selectEntry{
 	// Precision: fire via SDK/OS hooks, no DNS dependency, zero false positives
-	{bait.TypeAWSProc,    "precision", "~/.aws/config (credential_process)"},
-	{bait.TypeSSH,        "precision", "~/.ssh/config (ProxyCommand)"},
-	{bait.TypeK8s,        "precision", "~/.kube/<name>.yaml (server URL)"},
+	{bait.TypeAWSProc, "precision", "~/.aws/config (credential_process)"},
+	{bait.TypeSSH, "precision", "~/.ssh/config (ProxyCommand)"},
+	{bait.TypeK8s, "precision", "~/.kube/<name>.yaml (server URL)"},
 	// High: fires on active use, agent must find+use the credential
-	{bait.TypeAWS,        "high",      "~/.aws/credentials (endpoint_url)"},
-	{bait.TypeGCP,        "high",      "~/.config/gcloud/sa-*.json (token_uri)"},
-	{bait.TypeNPM,        "high",      "~/.npmrc (scoped registry)"},
-	{bait.TypeGit,        "high",      "~/.gitconfig (credential.helper)"},
-	{bait.TypePyPI,       "high",      "~/.config/pip/pip.conf (extra-index-url) ⚠ side effect"},
+	{bait.TypeAWS, "high", "~/.aws/credentials (endpoint_url)"},
+	{bait.TypeGCP, "high", "~/.config/gcloud/sa-*.json (token_uri)"},
+	{bait.TypeNPM, "high", "~/.npmrc (scoped registry)"},
+	{bait.TypeGit, "high", "~/.gitconfig (credential.helper)"},
+	{bait.TypePyPI, "high", "~/.config/pip/pip.conf (extra-index-url) ⚠ side effect"},
 	// Medium: dotenv-dependent, DNS-dependent, or needs explicit credential scanning
-	{bait.TypeAzure,      "medium",    "~/.azure/service-principal-credentials.json"},
-	{bait.TypeOpenAI,     "medium",    "~/.env (OPENAI_BASE_URL)"},
-	{bait.TypeAnthropic,  "medium",    "~/.env.local (ANTHROPIC_BASE_URL)"},
-	{bait.TypeMCP,        "medium",    "~/.config/mcp-servers*.json"},
-	{bait.TypeGitHub,     "medium",    "~/.config/gh/hosts.yml"},
-	{bait.TypeStripe,     "medium",    "~/.config/stripe/config.toml"},
-	{bait.TypeHuggingFace,"medium",    "~/.env.hf (HF_ENDPOINT)"},
-	{bait.TypeDocker,     "medium",    "~/.docker/config.json"},
-	{bait.TypeTerraform,  "medium",    "~/.terraformrc (network_mirror)"},
-	{bait.TypeGeneric,    "medium",    "~/.env.production (API_BASE_URL)"},
+	{bait.TypeAzure, "medium", "~/.azure/service-principal-credentials.json"},
+	{bait.TypeOpenAI, "medium", "~/.env (OPENAI_BASE_URL)"},
+	{bait.TypeAnthropic, "medium", "~/.env.local (ANTHROPIC_BASE_URL)"},
+	{bait.TypeMCP, "medium", "~/.config/mcp-servers*.json"},
+	{bait.TypeGitHub, "medium", "~/.config/gh/hosts.yml"},
+	{bait.TypeStripe, "medium", "~/.config/stripe/config.toml"},
+	{bait.TypeHuggingFace, "medium", "~/.env.hf (HF_ENDPOINT)"},
+	{bait.TypeDocker, "medium", "~/.docker/config.json"},
+	{bait.TypeTerraform, "medium", "~/.terraformrc (network_mirror)"},
+	{bait.TypeGeneric, "medium", "~/.env.production (API_BASE_URL)"},
 }
 
 // runSelectTUI shows an interactive checklist and returns the chosen types.
@@ -81,8 +81,8 @@ func runSelectTUI() ([]bait.Type, error) {
 		"medium":    "\033[36m", // cyan
 	}
 	reset := "\033[0m"
-	bold  := "\033[1m"
-	dim   := "\033[2m"
+	bold := "\033[1m"
+	dim := "\033[2m"
 
 	// Put terminal in raw mode
 	oldState, err := makeRaw(int(os.Stdin.Fd()))
@@ -214,7 +214,7 @@ Running AI agents on this machine? The default precision mode won't fire on your
 Use --all to arm every canary type, or --select to pick interactively.
 
 Flags:
-  --webhook <url>    webhook URL (Discord, Slack, Telegram, PagerDuty, Teams)
+  --webhook <url>    webhook URL (Discord, Slack, Telegram, or custom JSON endpoint)
   --label <name>     name your canary (e.g. prod-admin-legacy-2024) — defaults to hostname
   --all              plant all canary types including dotenv-based ones
   --select           interactive checklist to pick which canaries to arm
@@ -236,10 +236,10 @@ Naming tip:
 	}
 
 	webhookURL := flagValue(args, "--webhook")
-	label      := flagValue(args, "--label")
-	dryRun     := hasFlag(args, "--dry-run")
-	armAll     := hasFlag(args, "--all")
-	armSelect  := hasFlag(args, "--select")
+	label := flagValue(args, "--label")
+	dryRun := hasFlag(args, "--dry-run")
+	armAll := hasFlag(args, "--all")
+	armSelect := hasFlag(args, "--select")
 
 	if label == "" {
 		if h, err := os.Hostname(); err == nil {
@@ -299,7 +299,7 @@ Naming tip:
 		}
 	}
 
-	// Step 2: Plant all high-reliability canaries
+	// Step 2: Plant selected canaries
 	m, err := manifest.Load()
 	if err != nil {
 		fatal(err)
@@ -322,8 +322,8 @@ Naming tip:
 		}
 		fmt.Printf("  Custom mode: planting %s\n", strings.Join(names, ", "))
 	case armAll:
-		armTypes = highReliabilityTypes
-		fmt.Println("  Full mode: planting all canary types (including dotenv-based)")
+		armTypes = allCanaryTypes
+		fmt.Println("  Full mode: planting all 18 canary types (including dotenv-based)")
 	default:
 		fmt.Println("  Precision mode: planting highest-signal canaries only (awsproc, ssh, k8s)")
 	}

--- a/internal/cli/cmd_plant.go
+++ b/internal/cli/cmd_plant.go
@@ -11,21 +11,37 @@ import (
 	"github.com/peg/snare/internal/manifest"
 )
 
-// armCanaryTypes are planted by default with `snare arm` — the full recommended set.
-// High reliability types fire when the SDK actually uses the credential.
-// Medium reliability types fire conditionally but are still valuable coverage.
-var highReliabilityTypes = []bait.Type{
-	bait.TypeAWS, bait.TypeAWSProc, bait.TypeGCP,
-	bait.TypeSSH, bait.TypeK8s, bait.TypePyPI,
-	bait.TypeOpenAI, bait.TypeAnthropic, bait.TypeNPM, bait.TypeMCP,
-	bait.TypeHuggingFace, bait.TypeDocker, bait.TypeAzure, bait.TypeTerraform,
+// allCanaryTypes is the canonical non-interactive "everything" set used by
+// `snare arm --all` and `snare plant --all`.
+//
+// Keep this in sync with allSelectEntries in cmd_arming.go and the implemented
+// bait.Type constants. Ordering matches the website/docs tier order.
+var allCanaryTypes = []bait.Type{
+	bait.TypeAWSProc,
+	bait.TypeSSH,
+	bait.TypeK8s,
+	bait.TypeAWS,
+	bait.TypeGCP,
+	bait.TypeNPM,
+	bait.TypeGit,
+	bait.TypePyPI,
+	bait.TypeAzure,
+	bait.TypeOpenAI,
+	bait.TypeAnthropic,
+	bait.TypeMCP,
+	bait.TypeGitHub,
+	bait.TypeStripe,
+	bait.TypeHuggingFace,
+	bait.TypeDocker,
+	bait.TypeTerraform,
+	bait.TypeGeneric,
 }
 
 // cmdPlant deploys canary credentials to this machine.
 func cmdPlant(args []string) {
-	label    := flagValue(args, "--label")
+	label := flagValue(args, "--label")
 	baitType := flagValue(args, "--type")
-	dryRun   := hasFlag(args, "--dry-run")
+	dryRun := hasFlag(args, "--dry-run")
 	plantAll := hasFlag(args, "--all")
 
 	// Default label to hostname
@@ -47,9 +63,9 @@ func cmdPlant(args []string) {
 		fatal(err)
 	}
 
-	// --all plants all high-reliability types
+	// --all plants every implemented canary type.
 	if plantAll {
-		for _, bt := range highReliabilityTypes {
+		for _, bt := range allCanaryTypes {
 			plantOne(bt, label, cfg, m, dryRun)
 		}
 		return

--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/peg/snare/internal/serve"
@@ -18,6 +19,7 @@ func cmdServe(args []string) {
 	tlsDomain  := flagValue(args, "--tls-domain")
 	webhookURL := flagValue(args, "--webhook-url")
 	dashToken  := flagValue(args, "--dashboard-token")
+	trustedProxy := flagValue(args, "--trusted-proxy")
 
 	// Also accept token from env var
 	if dashToken == "" {
@@ -56,6 +58,9 @@ func cmdServe(args []string) {
 	}
 	if webhookURL != "" {
 		cfg.WebhookURL = webhookURL
+	}
+	if trustedProxy != "" {
+		cfg.TrustedProxyCIDRs = strings.Split(trustedProxy, ",")
 	}
 
 	srv, err := serve.New(cfg)

--- a/internal/cli/cmd_status.go
+++ b/internal/cli/cmd_status.go
@@ -109,19 +109,13 @@ func cmdRotate(args []string) {
 
 	fmt.Println("  Rotating device secret...")
 	fmt.Printf("  Old secret: %s...%s\n", cfg.DeviceSecret[:4], cfg.DeviceSecret[len(cfg.DeviceSecret)-4:])
+	oldSecret := cfg.DeviceSecret
 
 	// Generate new secret
 	newSecret, err := config.NewDeviceSecret()
 	if err != nil {
 		fatal(fmt.Errorf("generating new secret: %w", err))
 	}
-
-	// Update config
-	cfg.DeviceSecret = newSecret
-	if err := cfg.Save(); err != nil {
-		fatal(fmt.Errorf("saving config: %w", err))
-	}
-	fmt.Println("  ✓ New secret saved to ~/.snare/config.json")
 
 	// Re-register all active tokens with new secret
 	m, err := manifest.Load()
@@ -139,23 +133,27 @@ func cmdRotate(args []string) {
 	// Tell the server to update the stored secret hash for this device.
 	// This is the critical step — without it, all subsequent API calls will 401.
 	fmt.Println("  Updating server-side secret hash...")
-	rotateResp, err := authedPost(cfg.RotateURL(), map[string]string{
-		"device_id":  cfg.DeviceID,
-		"new_secret": newSecret,
-	}, cfg)
+	rotateResp, err := rotateDeviceSecretOnServer(cfg, oldSecret, newSecret)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "  ✗ server rotation failed: %v\n", err)
-		fmt.Fprintf(os.Stderr, "  Config saved locally — run `snare rotate` again once connectivity is restored.\n")
+		fmt.Fprintf(os.Stderr, "  Local config unchanged — old secret still active.\n")
 		return
 	}
 	defer rotateResp.Body.Close()
 	if rotateResp.StatusCode != 200 {
 		body, _ := io.ReadAll(rotateResp.Body)
 		fmt.Fprintf(os.Stderr, "  ✗ server rotation failed (HTTP %d): %s\n", rotateResp.StatusCode, strings.TrimSpace(string(body)))
-		fmt.Fprintf(os.Stderr, "  Config saved locally — run `snare rotate` again once the issue is resolved.\n")
+		fmt.Fprintf(os.Stderr, "  Local config unchanged — old secret still active.\n")
 		return
 	}
 	fmt.Println("  ✓ Server secret hash updated")
+
+	// Update local config only after the server accepted the new secret.
+	cfg.DeviceSecret = newSecret
+	if err := cfg.Save(); err != nil {
+		fatal(fmt.Errorf("saving config: %w", err))
+	}
+	fmt.Println("  ✓ New secret saved to ~/.snare/config.json")
 
 	// Re-register all active tokens with new secret
 	if len(active) > 0 {
@@ -174,10 +172,19 @@ func cmdRotate(args []string) {
 	fmt.Println("  ✓ Rotation complete. Old secret is now invalid.")
 }
 
+func rotateDeviceSecretOnServer(cfg *config.Config, oldSecret, newSecret string) (*http.Response, error) {
+	rotateCfg := *cfg
+	rotateCfg.DeviceSecret = oldSecret
+	return authedPost(cfg.RotateURL(), map[string]string{
+		"device_id":  cfg.DeviceID,
+		"new_secret": newSecret,
+	}, &rotateCfg)
+}
+
 // cmdInit sets up snare for this machine.
 // With --webhook: non-interactive. Without: guided setup.
 func cmdInit(args []string) {
-	force      := hasFlag(args, "--force")
+	force := hasFlag(args, "--force")
 	webhookURL := flagValue(args, "--webhook")
 
 	// Non-interactive path: --webhook provided (CI, scripting)

--- a/internal/cli/rotate_test.go
+++ b/internal/cli/rotate_test.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/peg/snare/internal/config"
+)
+
+func TestRotateDeviceSecretOnServerUsesOldSecret(t *testing.T) {
+	const (
+		oldSecret = "oldsecret000000000000000000000001"
+		newSecret = "newsecret000000000000000000000001"
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/rotate" {
+			t.Fatalf("path = %s, want /api/rotate", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer "+oldSecret {
+			t.Fatalf("Authorization = %q, want old secret", got)
+		}
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["new_secret"] != newSecret {
+			t.Fatalf("new_secret = %q, want %q", body["new_secret"], newSecret)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"rotated"}`))
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{
+		DeviceID:     "dev-rotate-test",
+		DeviceSecret: newSecret,
+		CallbackBase: srv.URL + "/c",
+	}
+
+	resp, err := rotateDeviceSecretOnServer(cfg, oldSecret, newSecret)
+	if err != nil {
+		t.Fatalf("rotateDeviceSecretOnServer: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}

--- a/internal/serve/db.go
+++ b/internal/serve/db.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	_ "modernc.org/sqlite" // pure-Go SQLite driver, no CGo
@@ -34,6 +35,7 @@ CREATE TABLE IF NOT EXISTS tokens (
 CREATE TABLE IF NOT EXISTS events (
 	id         INTEGER PRIMARY KEY AUTOINCREMENT,
 	token_id   TEXT NOT NULL,
+	device_id  TEXT,
 	is_test    INTEGER NOT NULL DEFAULT 0,
 	timestamp  TEXT NOT NULL,
 	ip         TEXT,
@@ -76,6 +78,9 @@ func openDB(path string) (*DB, error) {
 	if _, err := db.Exec(schema); err != nil {
 		return nil, fmt.Errorf("schema: %w", err)
 	}
+	if _, err := db.Exec(`ALTER TABLE events ADD COLUMN device_id TEXT`); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+		return nil, fmt.Errorf("add events.device_id column: %w", err)
+	}
 
 	return &DB{db: db}, nil
 }
@@ -110,6 +115,20 @@ func (d *DB) deviceSecretHash(deviceID string) (string, error) {
 		return "", nil
 	}
 	return h, err
+}
+
+// updateDeviceSecret replaces the stored secret hash for an existing device.
+// Returns (false, nil) when the device does not exist.
+func (d *DB) updateDeviceSecret(deviceID, deviceSecret string) (bool, error) {
+	res, err := d.db.Exec(`UPDATE devices SET secret_hash = ? WHERE device_id = ?`, hashSecret(deviceSecret), deviceID)
+	if err != nil {
+		return false, err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows > 0, nil
 }
 
 // ─── Token (webhook registration) operations ─────────────────────────────────
@@ -165,6 +184,7 @@ func (d *DB) deleteToken(tokenID string) error {
 type event struct {
 	ID        int64
 	TokenID   string
+	DeviceID  string
 	IsTest    bool
 	Timestamp string
 	IP        string
@@ -188,16 +208,16 @@ func (d *DB) insertEvent(e event) error {
 		isTest = 1
 	}
 	_, err := d.db.Exec(`
-		INSERT INTO events (token_id, is_test, timestamp, ip, user_agent, method, path, country, city, asn, asn_org, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, e.TokenID, isTest, e.Timestamp, e.IP, e.UserAgent, e.Method, e.Path, e.Country, e.City, e.ASN, e.ASNOrg, e.CreatedAt)
+		INSERT INTO events (token_id, device_id, is_test, timestamp, ip, user_agent, method, path, country, city, asn, asn_org, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, e.TokenID, e.DeviceID, isTest, e.Timestamp, e.IP, e.UserAgent, e.Method, e.Path, e.Country, e.City, e.ASN, e.ASNOrg, e.CreatedAt)
 	return err
 }
 
 // getEvents returns recent events for a token (newest first, limit 20).
 func (d *DB) getEvents(tokenID string) ([]event, error) {
 	rows, err := d.db.Query(`
-		SELECT id, token_id, is_test, timestamp, COALESCE(ip,''), COALESCE(user_agent,''),
+		SELECT id, token_id, COALESCE(device_id,''), is_test, timestamp, COALESCE(ip,''), COALESCE(user_agent,''),
 		       COALESCE(method,''), COALESCE(path,''), COALESCE(country,''), COALESCE(city,''),
 		       COALESCE(asn,''), COALESCE(asn_org,''), created_at
 		FROM events
@@ -215,7 +235,7 @@ func (d *DB) getEvents(tokenID string) ([]event, error) {
 // recentEvents returns the most recent events across all tokens (for dashboard).
 func (d *DB) recentEvents(limit int) ([]event, error) {
 	rows, err := d.db.Query(`
-		SELECT e.id, e.token_id, e.is_test, e.timestamp, COALESCE(e.ip,''), COALESCE(e.user_agent,''),
+		SELECT e.id, e.token_id, COALESCE(e.device_id,''), e.is_test, e.timestamp, COALESCE(e.ip,''), COALESCE(e.user_agent,''),
 		       COALESCE(e.method,''), COALESCE(e.path,''), COALESCE(e.country,''), COALESCE(e.city,''),
 		       COALESCE(e.asn,''), COALESCE(e.asn_org,''), e.created_at
 		FROM events e
@@ -235,7 +255,7 @@ func scanEvents(rows *sql.Rows) ([]event, error) {
 		var e event
 		var isTest int
 		if err := rows.Scan(
-			&e.ID, &e.TokenID, &isTest, &e.Timestamp,
+			&e.ID, &e.TokenID, &e.DeviceID, &isTest, &e.Timestamp,
 			&e.IP, &e.UserAgent, &e.Method, &e.Path,
 			&e.Country, &e.City, &e.ASN, &e.ASNOrg, &e.CreatedAt,
 		); err != nil {
@@ -247,10 +267,27 @@ func scanEvents(rows *sql.Rows) ([]event, error) {
 	return out, rows.Err()
 }
 
+// latestEventDeviceID returns the owner device recorded on the newest stored event.
+// Returns ("", nil) when no events exist or legacy events lack device ownership.
+func (d *DB) latestEventDeviceID(tokenID string) (string, error) {
+	var deviceID string
+	err := d.db.QueryRow(`
+		SELECT COALESCE(device_id,'')
+		FROM events
+		WHERE token_id = ?
+		ORDER BY timestamp DESC
+		LIMIT 1
+	`, tokenID).Scan(&deviceID)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return deviceID, err
+}
+
 // listDevices returns all registered devices (for dashboard).
 type deviceRow struct {
-	DeviceID  string
-	CreatedAt string
+	DeviceID   string
+	CreatedAt  string
 	TokenCount int
 }
 

--- a/internal/serve/handlers.go
+++ b/internal/serve/handlers.go
@@ -36,7 +36,7 @@ func (s *Server) handleCanary(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Capture metadata from headers ONLY — body is never touched.
-	ip := clientIP(r)
+	ip := clientIP(r, s.trustedProxyNets)
 	ua := r.Header.Get("User-Agent")
 	now := time.Now().UTC().Format(time.RFC3339)
 	method := r.Method
@@ -58,8 +58,16 @@ func (s *Server) handleCanary(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) processAlert(token, ip, ua, method, path, timestamp string, isTest bool) {
+	// Look up token registration first so stored events retain ownership
+	// even after a token is later revoked.
+	reg, err := s.db.getToken(token)
+	if err != nil {
+		log.Printf("get token error: %v", err)
+	}
+
 	e := event{
 		TokenID:   token,
+		DeviceID:  "",
 		IsTest:    isTest,
 		Timestamp: timestamp,
 		IP:        ip,
@@ -68,17 +76,14 @@ func (s *Server) processAlert(token, ip, ua, method, path, timestamp string, isT
 		Path:      path,
 		CreatedAt: timestamp,
 	}
+	if reg != nil {
+		e.DeviceID = reg.DeviceID
+	}
 
 	log.Printf("CANARY_FIRED token=%s ip=%s is_test=%v ua=%s", token, ip, isTest, truncate(ua, 80))
 
 	if err := s.db.insertEvent(e); err != nil {
 		log.Printf("insert event error: %v", err)
-	}
-
-	// Look up token registration for webhook and metadata
-	reg, err := s.db.getToken(token)
-	if err != nil {
-		log.Printf("get token error: %v", err)
 	}
 
 	// Unregistered tokens never fire webhooks — avoids false alerts from
@@ -273,6 +278,57 @@ func (s *Server) handleRevoke(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// ─── POST /api/rotate ────────────────────────────────────────────────────────
+
+func (s *Server) handleRotate(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		jsonResp(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	var body struct {
+		DeviceID  string `json:"device_id"`
+		NewSecret string `json:"new_secret"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		jsonResp(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		return
+	}
+	if body.DeviceID == "" {
+		jsonResp(w, http.StatusBadRequest, map[string]string{"error": "missing device_id"})
+		return
+	}
+	if len(body.NewSecret) < 32 {
+		jsonResp(w, http.StatusBadRequest, map[string]string{"error": "new_secret too short (min 32 chars)"})
+		return
+	}
+
+	ok, err := s.validateDevice(r, body.DeviceID)
+	if err != nil {
+		jsonResp(w, http.StatusInternalServerError, map[string]string{"error": "auth error"})
+		return
+	}
+	if !ok {
+		jsonResp(w, http.StatusUnauthorized, map[string]string{"error": "invalid device secret"})
+		return
+	}
+
+	updated, err := s.db.updateDeviceSecret(body.DeviceID, body.NewSecret)
+	if err != nil {
+		jsonResp(w, http.StatusInternalServerError, map[string]string{"error": "db error"})
+		return
+	}
+	if !updated {
+		jsonResp(w, http.StatusUnauthorized, map[string]string{"error": "unknown device_id"})
+		return
+	}
+
+	jsonResp(w, http.StatusOK, map[string]string{
+		"status":    "rotated",
+		"device_id": body.DeviceID,
+	})
+}
+
 // ─── GET /api/events/{token} ─────────────────────────────────────────────────
 
 func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
@@ -299,6 +355,13 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	deviceID := ""
 	if reg != nil {
 		deviceID = reg.DeviceID
+	}
+	if deviceID == "" {
+		deviceID, err = s.db.latestEventDeviceID(tokenID)
+		if err != nil {
+			jsonResp(w, http.StatusInternalServerError, map[string]string{"error": "db error"})
+			return
+		}
 	}
 	if deviceID == "" {
 		deviceID = r.Header.Get("X-Snare-Device-Id")

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -67,6 +67,24 @@ func TestHandleCanary_invalidToken(t *testing.T) {
 	}
 }
 
+func TestClientIPOnlyTrustsConfiguredProxies(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/c/test-token-abc123", nil)
+	req.RemoteAddr = "198.51.100.10:1234"
+	req.Header.Set("X-Forwarded-For", "203.0.113.8")
+
+	if got := clientIP(req, nil); got != "198.51.100.10" {
+		t.Fatalf("clientIP without trusted proxies = %q, want remote addr", got)
+	}
+
+	trusted, err := parseTrustedProxyCIDRs([]string{"198.51.100.0/24"})
+	if err != nil {
+		t.Fatalf("parseTrustedProxyCIDRs: %v", err)
+	}
+	if got := clientIP(req, trusted); got != "203.0.113.8" {
+		t.Fatalf("clientIP with trusted proxy = %q, want forwarded IP", got)
+	}
+}
+
 func TestHandleCanary_storesEvent(t *testing.T) {
 	s := testServer(t)
 
@@ -205,7 +223,64 @@ func TestHandleCreateDevice_shortSecret(t *testing.T) {
 	}
 }
 
+func TestHandleRotate_updatesDeviceSecret(t *testing.T) {
+	s := testServer(t)
+
+	const (
+		deviceID  = "dev-rotate-test"
+		oldSecret = "oldsecret000000000000000000000001"
+		newSecret = "newsecret000000000000000000000001"
+	)
+	if err := s.db.createDevice(deviceID, oldSecret); err != nil {
+		t.Fatalf("createDevice: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]string{
+		"device_id":  deviceID,
+		"new_secret": newSecret,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/rotate", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+oldSecret)
+	rr := httptest.NewRecorder()
+
+	s.handleRotate(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	oldReq := httptest.NewRequest(http.MethodPost, "/api/register", nil)
+	oldReq.Header.Set("Authorization", "Bearer "+oldSecret)
+	ok, err := s.validateDevice(oldReq, deviceID)
+	if err != nil {
+		t.Fatalf("validateDevice old secret: %v", err)
+	}
+	if ok {
+		t.Fatal("old secret still valid after rotation")
+	}
+
+	newReq := httptest.NewRequest(http.MethodPost, "/api/register", nil)
+	newReq.Header.Set("Authorization", "Bearer "+newSecret)
+	ok, err = s.validateDevice(newReq, deviceID)
+	if err != nil {
+		t.Fatalf("validateDevice new secret: %v", err)
+	}
+	if !ok {
+		t.Fatal("new secret not valid after rotation")
+	}
+}
+
 // ─── Health ──────────────────────────────────────────────────────────────────
+
+func TestDiscordPayloadFooterMatchesWorkerPrivacyCopy(t *testing.T) {
+	payload := buildDiscordPayload(event{TokenID: "tok-12345678", Timestamp: "2026-04-15T16:00:00Z", Method: "GET", IP: "1.2.3.4", UserAgent: "ua"}, nil, canaryTypeMeta{Name: "Canary", Emoji: "🎣"}, false)
+	embeds := payload["embeds"].([]map[string]interface{})
+	footer := embeds[0]["footer"].(map[string]string)["text"]
+	if footer != "snare-server · IP, UA, timestamp only — no request body" {
+		t.Fatalf("footer = %q", footer)
+	}
+}
 
 func TestHandleHealth(t *testing.T) {
 	s := testServer(t)
@@ -308,6 +383,61 @@ func TestHandleCanary_registeredTokenFiresWebhook(t *testing.T) {
 
 	if !called {
 		t.Error("webhook was NOT called for a registered token — expected webhook delivery")
+	}
+}
+
+func TestHandleEventsAfterRevokeStillRequiresOriginalOwner(t *testing.T) {
+	s := testServer(t)
+
+	const (
+		ownerDeviceID  = "dev-owner-001"
+		ownerSecret    = "ownersecret0000000000000000000001"
+		otherDeviceID  = "dev-other-001"
+		otherSecret    = "othersecret0000000000000000000001"
+		tokenID        = "token-events-abc123"
+		registeredAt   = "2026-04-27T22:00:00Z"
+		eventTimestamp = "2026-04-27T22:05:00Z"
+	)
+
+	if err := s.db.createDevice(ownerDeviceID, ownerSecret); err != nil {
+		t.Fatalf("create owner device: %v", err)
+	}
+	if err := s.db.createDevice(otherDeviceID, otherSecret); err != nil {
+		t.Fatalf("create other device: %v", err)
+	}
+	if err := s.db.upsertToken(tokenReg{
+		TokenID:      tokenID,
+		DeviceID:     ownerDeviceID,
+		WebhookURL:   "use-global",
+		CanaryType:   "awsproc",
+		Label:        "prod",
+		RegisteredAt: registeredAt,
+	}); err != nil {
+		t.Fatalf("upsertToken: %v", err)
+	}
+
+	s.processAlert(tokenID, "1.2.3.4", "curl/8.0", "GET", "/c/"+tokenID, eventTimestamp, false)
+
+	if err := s.db.deleteToken(tokenID); err != nil {
+		t.Fatalf("deleteToken: %v", err)
+	}
+
+	unauthReq := httptest.NewRequest(http.MethodGet, "/api/events/"+tokenID, nil)
+	unauthReq.Header.Set("Authorization", "Bearer "+otherSecret)
+	unauthReq.Header.Set("X-Snare-Device-Id", otherDeviceID)
+	unauthRR := httptest.NewRecorder()
+	s.handleEvents(unauthRR, unauthReq)
+	if unauthRR.Code != http.StatusUnauthorized {
+		t.Fatalf("wrong owner status = %d, want 401", unauthRR.Code)
+	}
+
+	ownerReq := httptest.NewRequest(http.MethodGet, "/api/events/"+tokenID, nil)
+	ownerReq.Header.Set("Authorization", "Bearer "+ownerSecret)
+	ownerReq.Header.Set("X-Snare-Device-Id", ownerDeviceID)
+	ownerRR := httptest.NewRecorder()
+	s.handleEvents(ownerRR, ownerReq)
+	if ownerRR.Code != http.StatusOK {
+		t.Fatalf("owner status = %d, want 200: %s", ownerRR.Code, ownerRR.Body.String())
 	}
 }
 

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -23,11 +23,12 @@ const sessionCookieName = "snare_session"
 
 // Config holds the server configuration.
 type Config struct {
-	Port           int    // listen port (default 8080)
-	DBPath         string // path to SQLite database
-	TLSDomain      string // if set, enable Let's Encrypt TLS
-	WebhookURL     string // global fallback webhook URL
-	DashboardToken string // bearer token for dashboard + dashboard API auth (required)
+	Port              int      // listen port (default 8080)
+	DBPath            string   // path to SQLite database
+	TLSDomain         string   // if set, enable Let's Encrypt TLS
+	WebhookURL        string   // global fallback webhook URL
+	DashboardToken    string   // bearer token for dashboard + dashboard API auth (required)
+	TrustedProxyCIDRs []string // trusted reverse proxies allowed to supply X-Forwarded-For / X-Real-IP
 }
 
 // DefaultConfig returns sensible defaults.
@@ -41,10 +42,11 @@ func DefaultConfig() Config {
 
 // Server is the snare self-hosted server.
 type Server struct {
-	cfg           Config
-	db            *DB
-	mux           *http.ServeMux
-	sessionSecret []byte // random secret generated at startup for HMAC session cookies
+	cfg              Config
+	db               *DB
+	mux              *http.ServeMux
+	sessionSecret    []byte // random secret generated at startup for HMAC session cookies
+	trustedProxyNets []*net.IPNet
 }
 
 // tokenPattern validates token IDs in URL paths.
@@ -71,7 +73,12 @@ func New(cfg Config) (*Server, error) {
 		return nil, fmt.Errorf("generating session secret: %w", err)
 	}
 
-	s := &Server{cfg: cfg, db: db, mux: http.NewServeMux(), sessionSecret: secret}
+	trustedProxyNets, err := parseTrustedProxyCIDRs(cfg.TrustedProxyCIDRs)
+	if err != nil {
+		return nil, fmt.Errorf("parsing trusted proxy CIDRs: %w", err)
+	}
+
+	s := &Server{cfg: cfg, db: db, mux: http.NewServeMux(), sessionSecret: secret, trustedProxyNets: trustedProxyNets}
 	s.routes()
 	return s, nil
 }
@@ -86,6 +93,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("/api/devices", s.handleCreateDevice)
 	s.mux.HandleFunc("/api/register", s.handleRegister)
 	s.mux.HandleFunc("/api/revoke", s.handleRevoke)
+	s.mux.HandleFunc("/api/rotate", s.handleRotate)
 	s.mux.HandleFunc("/api/events/", s.handleEvents)
 
 	// Dashboard auth: login / logout
@@ -323,19 +331,71 @@ func jsonResp(w http.ResponseWriter, status int, v interface{}) {
 	_ = json.NewEncoder(w).Encode(v)
 }
 
-func clientIP(r *http.Request) string {
-	// Honour standard proxy headers when running behind a reverse proxy.
-	if ip := r.Header.Get("X-Forwarded-For"); ip != "" {
-		// X-Forwarded-For can contain a comma-separated list; take the first.
-		if parts := strings.SplitN(ip, ",", 2); len(parts) > 0 {
-			return strings.TrimSpace(parts[0])
+func clientIP(r *http.Request, trustedProxyNets []*net.IPNet) string {
+	remoteIP := remoteAddrIP(r.RemoteAddr)
+	if trustedProxy(remoteIP, trustedProxyNets) {
+		if ip := firstForwardedIP(r.Header.Get("X-Forwarded-For")); ip != "" {
+			return ip
+		}
+		if ip := strings.TrimSpace(r.Header.Get("X-Real-Ip")); ip != "" {
+			return ip
 		}
 	}
-	if ip := r.Header.Get("X-Real-Ip"); ip != "" {
-		return ip
+	return remoteIP
+}
+
+func remoteAddrIP(remoteAddr string) string {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err == nil {
+		return host
 	}
-	host, _, _ := net.SplitHostPort(r.RemoteAddr)
-	return host
+	return remoteAddr
+}
+
+func firstForwardedIP(xff string) string {
+	if xff == "" {
+		return ""
+	}
+	parts := strings.SplitN(xff, ",", 2)
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(parts[0])
+}
+
+func parseTrustedProxyCIDRs(cidrs []string) ([]*net.IPNet, error) {
+	if len(cidrs) == 0 {
+		return nil, nil
+	}
+	trusted := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		cidr = strings.TrimSpace(cidr)
+		if cidr == "" {
+			continue
+		}
+		_, network, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return nil, fmt.Errorf("%q: %w", cidr, err)
+		}
+		trusted = append(trusted, network)
+	}
+	return trusted, nil
+}
+
+func trustedProxy(remoteIP string, trustedProxyNets []*net.IPNet) bool {
+	if len(trustedProxyNets) == 0 {
+		return false
+	}
+	ip := net.ParseIP(remoteIP)
+	if ip == nil {
+		return false
+	}
+	for _, network := range trustedProxyNets {
+		if network.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }
 
 // newID generates a random hex-encoded ID with the given prefix.

--- a/internal/serve/webhook.go
+++ b/internal/serve/webhook.go
@@ -17,20 +17,24 @@ type canaryTypeMeta struct {
 }
 
 var canaryTypes = map[string]canaryTypeMeta{
-	"aws":       {Emoji: "🔑", Name: "AWS"},
-	"gcp":       {Emoji: "☁️", Name: "GCP"},
-	"github":    {Emoji: "⬛", Name: "GitHub"},
-	"stripe":    {Emoji: "💳", Name: "Stripe"},
-	"openai":    {Emoji: "🤖", Name: "OpenAI"},
-	"anthropic": {Emoji: "🟠", Name: "Anthropic"},
-	"ssh":       {Emoji: "🔒", Name: "SSH"},
-	"k8s":       {Emoji: "☸️", Name: "Kubernetes"},
-	"npm":       {Emoji: "📦", Name: "npm"},
-	"mcp":       {Emoji: "🔌", Name: "MCP"},
-	"pypi":      {Emoji: "🐍", Name: "PyPI"},
-	"awsproc":   {Emoji: "⚙️", Name: "AWS (credential_process)"},
-	"docker":    {Emoji: "🐳", Name: "Docker"},
-	"generic":   {Emoji: "🗝️", Name: "Generic"},
+	"aws":         {Emoji: "🔑", Name: "AWS"},
+	"gcp":         {Emoji: "☁️", Name: "GCP"},
+	"github":      {Emoji: "⬛", Name: "GitHub"},
+	"stripe":      {Emoji: "💳", Name: "Stripe"},
+	"openai":      {Emoji: "🤖", Name: "OpenAI"},
+	"anthropic":   {Emoji: "🟠", Name: "Anthropic"},
+	"ssh":         {Emoji: "🔒", Name: "SSH"},
+	"k8s":         {Emoji: "☸️", Name: "Kubernetes"},
+	"npm":         {Emoji: "📦", Name: "npm"},
+	"mcp":         {Emoji: "🔌", Name: "MCP"},
+	"pypi":        {Emoji: "🐍", Name: "PyPI"},
+	"awsproc":     {Emoji: "⚙️", Name: "AWS (credential_process)"},
+	"huggingface": {Emoji: "🤗", Name: "Hugging Face"},
+	"docker":      {Emoji: "🐳", Name: "Docker"},
+	"azure":       {Emoji: "🔷", Name: "Azure"},
+	"git":         {Emoji: "🌿", Name: "Git"},
+	"terraform":   {Emoji: "🧱", Name: "Terraform"},
+	"generic":     {Emoji: "🗝️", Name: "Generic"},
 }
 
 var defaultCanaryType = canaryTypeMeta{Emoji: "🪤", Name: "Canary"}
@@ -96,12 +100,12 @@ func deliverWebhook(webhookURL string, e event, reg *tokenReg) {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Printf("webhook delivery error token=%s: %v", e.TokenID, err)
+		log.Printf("webhook delivery error token=*** url=***: %v", err)
 		return
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
-		log.Printf("webhook returned %d for token=%s url=%s", resp.StatusCode, e.TokenID, webhookURL)
+		log.Printf("webhook returned %d for token=*** url=***", resp.StatusCode)
 	}
 }
 
@@ -157,7 +161,7 @@ func buildDiscordPayload(e event, reg *tokenReg, ct canaryTypeMeta, fromCloud bo
 				"title":     title,
 				"color":     color,
 				"fields":    fields,
-				"footer":    map[string]string{"text": "snare-server · request body was never captured"},
+				"footer":    map[string]string{"text": "snare-server · IP, UA, timestamp only — no request body"},
 				"timestamp": e.Timestamp,
 			},
 		},
@@ -199,7 +203,7 @@ func buildSlackPayload(e event, reg *tokenReg, ct canaryTypeMeta, fromCloud bool
 			{
 				"color":  "#B2121A",
 				"fields": fields,
-				"footer": "snare-server · request body was never captured",
+				"footer": "snare-server · IP, UA, timestamp only — no request body",
 			},
 		},
 	}

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -247,17 +247,23 @@ func encodeBase64Lines(data []byte, lineLen int) string {
 func NewK8sToken() (string, error) {
 	// JWT header (always the same for k8s SA tokens)
 	header := "eyJhbGciOiJSUzI1NiIsImtpZCI6IkNnY3cifQ"
-	// Random payload (64 bytes → ~86 base64url chars)
-	payload := make([]byte, 64)
-	if _, err := rand.Read(payload); err != nil {
-		return "", err
+	for attempt := 0; attempt < 1000; attempt++ {
+		// Random payload (64 bytes → ~86 base64url chars)
+		payload := make([]byte, 64)
+		if _, err := rand.Read(payload); err != nil {
+			return "", err
+		}
+		// Random signature (128 bytes → ~172 base64url chars)
+		sig := make([]byte, 128)
+		if _, err := rand.Read(sig); err != nil {
+			return "", err
+		}
+		token := header + "." + base64url(payload) + "." + base64url(sig)
+		if !containsGiveaway(token) {
+			return token, nil
+		}
 	}
-	// Random signature (128 bytes → ~172 base64url chars)
-	sig := make([]byte, 128)
-	if _, err := rand.Read(sig); err != nil {
-		return "", err
-	}
-	return header + "." + base64url(payload) + "." + base64url(sig), nil
+	return "", fmt.Errorf("failed to generate giveaway-free k8s token after 1000 attempts")
 }
 
 // NewNPMToken generates a realistic npm auth token.
@@ -295,12 +301,12 @@ func NewHuggingFaceToken() (string, error) {
 
 // NewDockerRegistryName generates a convincing fake Docker registry hostname.
 // Format: registry.prod-services-XXXXX.io
-func NewDockerRegistryName() string {
+func NewDockerRegistryName() (string, error) {
 	b := make([]byte, 4)
 	if _, err := rand.Read(b); err != nil {
-		panic(fmt.Sprintf("crypto/rand failure: %v", err))
+		return "", err
 	}
-	return fmt.Sprintf("registry.prod-services-%x.io", b)
+	return fmt.Sprintf("registry.prod-services-%x.io", b), nil
 }
 
 // NewAzureClientID generates a realistic Azure AD application (client) ID.

--- a/worker/index.js
+++ b/worker/index.js
@@ -198,7 +198,7 @@ export default {
       // Process alert asynchronously AFTER response is sent to caller
       ctx.waitUntil(
         processAlert(token, metadata, env).catch(err =>
-          console.error(`ALERT_ERROR token=${token} err=${err.message}`)
+          console.error(`ALERT_ERROR token=*** err=${err.message}`)
         )
       );
 
@@ -276,15 +276,9 @@ async function validateAuth(request, env, deviceId) {
 
   const secretHash = await hashSecret(secret);
 
-  // Check if device is registered
   const storedRaw = await env.SNARE_KV.get(`device:${deviceId}`);
   if (!storedRaw) {
-    // First time — register this device
-    await env.SNARE_KV.put(`device:${deviceId}`, JSON.stringify({
-      secret_hash: secretHash,
-      registered_at: new Date().toISOString(),
-    }));
-    return { ok: true, deviceId, isNew: true };
+    return { ok: false, error: "unknown device_id" };
   }
 
   // Validate secret against stored hash
@@ -348,7 +342,7 @@ async function processAlert(token, metadata, env) {
   // Unregistered tokens must never fire webhooks — prevents false alerts from
   // probe traffic hitting random/partial token URLs (e.g. snare.sh/c/agent-01-).
   if (!registered && !token.startsWith("snare-test-")) {
-    console.log("UNREGISTERED_TOKEN", token, metadata.ip);
+    console.log("UNREGISTERED_TOKEN", "token=***", "ip=***");
     return;
   }
 
@@ -360,6 +354,7 @@ async function processAlert(token, metadata, env) {
 
   const event = {
     token,
+    device_id: meta.deviceId || null,
     is_test:   isTest,
     timestamp: metadata.timestamp,
     ip:        metadata.ip,
@@ -377,9 +372,9 @@ async function processAlert(token, metadata, env) {
 
   // Log metadata only — never body content
   console.log(isTest ? "CANARY_TEST" : "CANARY_FIRED", JSON.stringify({
-    token: event.token,
+    token: "***",
     is_test: event.is_test,
-    ip: event.ip,
+    ip: event.ip ? "***" : event.ip,
     method: event.method,
     country: event.country,
     asnOrg: event.asnOrg,
@@ -399,7 +394,7 @@ async function processAlert(token, metadata, env) {
   );
   results.forEach((r, i) => {
     if (r.status === "rejected") {
-      console.error(`WEBHOOK_FAILED url=${webhooks[i]} token=${token} err=${r.reason}`);
+      console.error(`WEBHOOK_FAILED url=*** token=*** err=${r.reason}`);
     }
   });
 }
@@ -418,6 +413,24 @@ async function handleEvents(token, request, env) {
       const reg = JSON.parse(regRaw);
       deviceId = reg.device_id;
     } catch { /* fall through */ }
+  }
+
+  // If the token is no longer registered, fall back to the owner recorded on
+  // the newest stored event so revoked tokens don't become readable by any
+  // random valid device.
+  if (!deviceId) {
+    const list = await env.SNARE_KV.list({ prefix: `event:${token}:`, limit: 20 });
+    for (const key of list.keys) {
+      const raw = await env.SNARE_KV.get(key.name);
+      if (!raw) continue;
+      try {
+        const event = JSON.parse(raw);
+        if (event.device_id) {
+          deviceId = event.device_id;
+          break;
+        }
+      } catch { /* skip corrupt */ }
+    }
   }
 
   // Auth required for ALL event reads — no unauthenticated fallback
@@ -901,4 +914,4 @@ function json(body, status = 200) {
 }
 
 // Named exports for unit testing — not used by the worker runtime
-export { CANARY_TYPES, shouldFilter, resolveWebhooks, SCANNER_ORGS };
+export { CANARY_TYPES, shouldFilter, resolveWebhooks, SCANNER_ORGS, validateAuth };

--- a/worker/index.test.js
+++ b/worker/index.test.js
@@ -1,5 +1,20 @@
 import { describe, it, expect } from "vitest";
-import { CANARY_TYPES, shouldFilter, resolveWebhooks, SCANNER_ORGS } from "./index.js";
+import { readFileSync } from "node:fs";
+import worker, { CANARY_TYPES, shouldFilter, resolveWebhooks, SCANNER_ORGS, validateAuth } from "./index.js";
+
+// ─── Log hygiene ────────────────────────────────────────────────────────────
+
+describe("log hygiene", () => {
+  it("does not log raw webhook URLs or canary token IDs in failure paths", () => {
+    const source = readFileSync(new URL("./index.js", import.meta.url), "utf8");
+
+    expect(source).not.toContain("ALERT_ERROR token=${token}");
+    expect(source).not.toContain('console.log("UNREGISTERED_TOKEN", token');
+    expect(source).not.toContain("WEBHOOK_FAILED url=${webhooks[i]} token=${token}");
+    expect(source).toContain("ALERT_ERROR token=***");
+    expect(source).toContain("WEBHOOK_FAILED url=*** token=***");
+  });
+});
 
 // ─── Token pattern validation ────────────────────────────────────────────────
 // The worker uses this regex for canary callback matching:
@@ -161,6 +176,91 @@ describe("CANARY_TYPES completeness", () => {
 });
 
 // ─── resolveWebhooks ─────────────────────────────────────────────────────────
+
+describe("validateAuth", () => {
+  it("rejects unknown devices instead of auto-registering them", async () => {
+    const req = new Request("https://snare.sh/api/register", {
+      headers: { authorization: "Bearer supersecret-supersecret-supersecret!!" },
+    });
+    const env = { SNARE_KV: { get: async () => null } };
+
+    const result = await validateAuth(req, env, "dev-missing");
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("unknown device_id");
+  });
+
+  it("accepts an existing device with the correct secret", async () => {
+    const encoder = new TextEncoder();
+    const hashBuf = await crypto.subtle.digest("SHA-256", encoder.encode("supersecret-supersecret-supersecret!!"));
+    const secretHash = Array.from(new Uint8Array(hashBuf)).map(b => b.toString(16).padStart(2, "0")).join("");
+
+    const req = new Request("https://snare.sh/api/register", {
+      headers: { authorization: "Bearer supersecret-supersecret-supersecret!!" },
+    });
+    const env = {
+      SNARE_KV: {
+        get: async (key) => key === "device:dev-known" ? JSON.stringify({ secret_hash: secretHash }) : null,
+      },
+    };
+
+    const result = await validateAuth(req, env, "dev-known");
+    expect(result.ok).toBe(true);
+    expect(result.deviceId).toBe("dev-known");
+  });
+});
+
+describe("event ownership after revoke", () => {
+  it("still requires the original owner device to read stored events", async () => {
+    const ownerSecret = "ownersecret000000000000000000000001";
+    const ownerDevice = "dev-owner";
+    const otherSecret = "othersecret000000000000000000000001";
+    const otherDevice = "dev-other";
+    const token = "token-events-abc123";
+
+    const sha256 = async (input) => {
+      const hashBuf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
+      return Array.from(new Uint8Array(hashBuf)).map(b => b.toString(16).padStart(2, "0")).join("");
+    };
+
+    const kv = new Map([
+      [`device:${ownerDevice}`, JSON.stringify({ secret_hash: await sha256(ownerSecret) })],
+      [`device:${otherDevice}`, JSON.stringify({ secret_hash: await sha256(otherSecret) })],
+      [`event:${token}:1:a`, JSON.stringify({ token, device_id: ownerDevice, timestamp: "2026-04-27T22:05:00Z", ip: "1.2.3.4" })],
+    ]);
+
+    const env = {
+      SNARE_KV: {
+        get: async (key) => kv.has(key) ? kv.get(key) : null,
+        put: async (key, value) => { kv.set(key, value); },
+        delete: async (key) => { kv.delete(key); },
+        list: async ({ prefix, limit }) => ({
+          keys: [...kv.keys()].filter(k => k.startsWith(prefix)).slice(0, limit).map(name => ({ name })),
+        }),
+      },
+    };
+
+    const wrongReq = new Request(`https://snare.sh/api/events/${token}`, {
+      headers: {
+        authorization: `Bearer ${otherSecret}`,
+        "x-snare-device-id": otherDevice,
+      },
+    });
+    const wrongResp = await worker.fetch(wrongReq, env, { waitUntil() {} });
+    expect(wrongResp.status).toBe(401);
+
+    const ownerReq = new Request(`https://snare.sh/api/events/${token}`, {
+      headers: {
+        authorization: `Bearer ${ownerSecret}`,
+        "x-snare-device-id": ownerDevice,
+      },
+    });
+    const ownerResp = await worker.fetch(ownerReq, env, { waitUntil() {} });
+    expect(ownerResp.status).toBe(200);
+    const body = await ownerResp.json();
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0].token).toBe(token);
+  });
+});
 
 describe("resolveWebhooks", () => {
   it("returns registered=true for a registered token", async () => {

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -6,449 +6,41 @@
     "": {
       "name": "snare-worker",
       "devDependencies": {
-        "vitest": "^3.1.1"
+        "vitest": "^4.1.5"
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
-      "cpu": [
-        "ppc64"
-      ],
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -458,24 +50,39 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
-      "integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ]
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
     },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
-      "integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
       "cpu": [
         "arm64"
       ],
@@ -484,12 +91,15 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
-      "integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
       "cpu": [
         "arm64"
       ],
@@ -498,12 +108,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
-      "integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
       "cpu": [
         "x64"
       ],
@@ -512,26 +125,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
-      "integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
-      "cpu": [
-        "arm64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
-      "integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
       "cpu": [
         "x64"
       ],
@@ -540,12 +142,15 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
-      "integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
       "cpu": [
         "arm"
       ],
@@ -554,26 +159,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
-      "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
-      "cpu": [
-        "arm"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
-      "integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
       "cpu": [
         "arm64"
       ],
@@ -582,12 +176,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
-      "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
       "cpu": [
         "arm64"
       ],
@@ -596,40 +193,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
-      "integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
-      "cpu": [
-        "loong64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
-      "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
-      "integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
       "cpu": [
         "ppc64"
       ],
@@ -638,54 +210,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
-      "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
-      "cpu": [
-        "ppc64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
-      "integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
-      "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
-      "integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
       "cpu": [
         "s390x"
       ],
@@ -694,12 +227,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
-      "integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
       "cpu": [
         "x64"
       ],
@@ -708,12 +244,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
-      "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
       "cpu": [
         "x64"
       ],
@@ -722,26 +261,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
-      "integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
-      "cpu": [
-        "x64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
-      "integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
       "cpu": [
         "arm64"
       ],
@@ -750,12 +278,34 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
-      "integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
       "cpu": [
         "arm64"
       ],
@@ -764,26 +314,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
-      "integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
-      "cpu": [
-        "ia32"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
-      "integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
       "cpu": [
         "x64"
       ],
@@ -792,21 +331,35 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
-      "integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
-      "cpu": [
-        "x64"
       ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "win32"
-      ]
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -834,39 +387,40 @@
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "4.1.5",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
+        "magic-string": "^0.30.21"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -878,42 +432,42 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^2.0.0"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
-        "pathe": "^2.0.3",
-        "strip-literal": "^3.0.0"
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "magic-string": "^0.30.17",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -921,28 +475,25 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -958,119 +509,39 @@
         "node": ">=12"
       }
     },
-    "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      }
-    },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/esbuild": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
-      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.4",
-        "@esbuild/android-arm": "0.27.4",
-        "@esbuild/android-arm64": "0.27.4",
-        "@esbuild/android-x64": "0.27.4",
-        "@esbuild/darwin-arm64": "0.27.4",
-        "@esbuild/darwin-x64": "0.27.4",
-        "@esbuild/freebsd-arm64": "0.27.4",
-        "@esbuild/freebsd-x64": "0.27.4",
-        "@esbuild/linux-arm": "0.27.4",
-        "@esbuild/linux-arm64": "0.27.4",
-        "@esbuild/linux-ia32": "0.27.4",
-        "@esbuild/linux-loong64": "0.27.4",
-        "@esbuild/linux-mips64el": "0.27.4",
-        "@esbuild/linux-ppc64": "0.27.4",
-        "@esbuild/linux-riscv64": "0.27.4",
-        "@esbuild/linux-s390x": "0.27.4",
-        "@esbuild/linux-x64": "0.27.4",
-        "@esbuild/netbsd-arm64": "0.27.4",
-        "@esbuild/netbsd-x64": "0.27.4",
-        "@esbuild/openbsd-arm64": "0.27.4",
-        "@esbuild/openbsd-x64": "0.27.4",
-        "@esbuild/openharmony-arm64": "0.27.4",
-        "@esbuild/sunos-x64": "0.27.4",
-        "@esbuild/win32-arm64": "0.27.4",
-        "@esbuild/win32-ia32": "0.27.4",
-        "@esbuild/win32-x64": "0.27.4"
-      }
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
@@ -1125,19 +596,266 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
     },
-    "node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
       "dev": true,
-      "license": "MIT"
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -1148,13 +866,6 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -1175,22 +886,23 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1213,9 +925,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {
@@ -1241,49 +953,38 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
-      "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.0",
-        "@rollup/rollup-android-arm64": "4.60.0",
-        "@rollup/rollup-darwin-arm64": "4.60.0",
-        "@rollup/rollup-darwin-x64": "4.60.0",
-        "@rollup/rollup-freebsd-arm64": "4.60.0",
-        "@rollup/rollup-freebsd-x64": "4.60.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.0",
-        "@rollup/rollup-linux-arm64-musl": "4.60.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.0",
-        "@rollup/rollup-linux-loong64-musl": "4.60.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.0",
-        "@rollup/rollup-linux-x64-gnu": "4.60.0",
-        "@rollup/rollup-linux-x64-musl": "4.60.0",
-        "@rollup/rollup-openbsd-x64": "4.60.0",
-        "@rollup/rollup-openharmony-arm64": "4.60.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.0",
-        "@rollup/rollup-win32-x64-gnu": "4.60.0",
-        "@rollup/rollup-win32-x64-msvc": "4.60.0",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
     "node_modules/siginfo": {
@@ -1311,24 +1012,11 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/strip-literal": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^9.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -1338,21 +1026,24 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -1361,49 +1052,36 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinypool": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
     "node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/tinyspy": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -1419,9 +1097,10 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -1434,13 +1113,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -1466,89 +1148,80 @@
         }
       }
     },
-    "node_modules/vite-node": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.4.1",
-        "es-module-lexer": "^1.7.0",
-        "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "debug": "^4.4.1",
-        "expect-type": "^1.2.1",
-        "magic-string": "^0.30.17",
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
-        "std-env": "^3.9.0",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.14",
-        "tinypool": "^1.1.1",
-        "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.4",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@types/debug": {
+        "@opentelemetry/api": {
           "optional": true
         },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser": {
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {
@@ -1559,6 +1232,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },

--- a/worker/package.json
+++ b/worker/package.json
@@ -6,6 +6,6 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "vitest": "^3.1.1"
+    "vitest": "^4.1.5"
   }
 }


### PR DESCRIPTION
## Summary
- align `arm --all` / `plant --all` around one canonical inventory of all 18 canary types
- add trusted-proxy CIDR handling for self-hosted IP attribution and document the safer default
- harden event/device ownership, rotation, webhook/log redaction, and k8s token generation
- add v0.2.0 changelog plus CI worker test coverage

## Verification
- `go test ./... -race -count=1`
- `(cd worker && npm test)`
- `go build ./...`
