### PR TITLE
fix: harden self-hosted callback metadata handling

### DIFF
--- a/internal/serve/handlers.go
+++ b/internal/serve/handlers.go
@@ -63,6 +63,13 @@ func (s *Server) processAlert(token, ip, ua, method, path, timestamp string, isT
 	if err != nil {
 		log.Printf("get token error: %v", err)
 	}
+	// Unregistered real tokens are usually scanners or typo/probe traffic. Match
+	// the managed Worker path: do not persist them and never relay webhooks.
+	// Test tokens remain allowed so local pipeline checks still produce events.
+	if reg == nil && !isTest {
+		log.Printf("UNREGISTERED token=*** ip=*** — skipping event and webhook")
+		return
+	}
 
 	e := event{
 		TokenID:   token,
@@ -79,17 +86,14 @@ func (s *Server) processAlert(token, ip, ua, method, path, timestamp string, isT
 		e.DeviceID = reg.DeviceID
 	}
 
-	log.Printf("CANARY_FIRED token=%s ip=%s is_test=%v ua=%s", token, ip, isTest, truncate(ua, 80))
+	logName := "CANARY_FIRED"
+	if isTest {
+		logName = "CANARY_TEST"
+	}
+	log.Printf("%s token=*** ip=*** is_test=%v ua=%s", logName, isTest, truncate(ua, 80))
 
 	if err := s.db.insertEvent(e); err != nil {
 		log.Printf("insert event error: %v", err)
-	}
-
-	// Unregistered tokens never fire webhooks — avoids false alerts from
-	// probe traffic hitting random/partial token URLs.
-	if reg == nil {
-		log.Printf("UNREGISTERED token=%s — skipping webhook", token)
-		return
 	}
 
 	// Determine webhook target

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -3,6 +3,7 @@ package serve
 import (
 	"bytes"
 	"encoding/json"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -26,6 +27,21 @@ func testServer(t *testing.T) *Server {
 	}
 	t.Cleanup(func() { s.db.close() })
 	return s
+}
+
+func captureLogs(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	oldWriter := log.Writer()
+	oldFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(oldWriter)
+		log.SetFlags(oldFlags)
+	}()
+	fn()
+	return buf.String()
 }
 
 // ─── Canary callback handler ──────────────────────────────────────────────────
@@ -85,13 +101,56 @@ func TestClientIPOnlyTrustsConfiguredProxies(t *testing.T) {
 	}
 }
 
+func TestClientIPRejectsMalformedTrustedProxyHeaders(t *testing.T) {
+	trusted, err := parseTrustedProxyCIDRs([]string{"198.51.100.0/24"})
+	if err != nil {
+		t.Fatalf("parseTrustedProxyCIDRs: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/c/test-token-abc123", nil)
+	req.RemoteAddr = "198.51.100.10:1234"
+	req.Header.Set("X-Forwarded-For", "not-an-ip")
+	req.Header.Set("X-Real-Ip", "203.0.113.9")
+	if got := clientIP(req, trusted); got != "203.0.113.9" {
+		t.Fatalf("clientIP with malformed XFF and valid X-Real-IP = %q, want X-Real-IP", got)
+	}
+
+	req.Header.Set("X-Real-Ip", "also-not-an-ip")
+	if got := clientIP(req, trusted); got != "198.51.100.10" {
+		t.Fatalf("clientIP with malformed forwarded headers = %q, want remote addr", got)
+	}
+}
+
 func TestHandleCanary_storesEvent(t *testing.T) {
 	s := testServer(t)
+	const tokenID = "stored-token123"
+
+	if err := s.db.createDevice("dev-store-test", "secret0000000000000000000000001"); err != nil {
+		t.Fatalf("createDevice: %v", err)
+	}
+	if err := s.db.upsertToken(tokenReg{
+		TokenID:      tokenID,
+		DeviceID:     "dev-store-test",
+		WebhookURL:   "",
+		CanaryType:   "aws",
+		Label:        "store-test",
+		RegisteredAt: "2024-01-01T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("upsertToken: %v", err)
+	}
 
 	// Call processAlert directly (it's synchronous in tests, no goroutine race).
-	s.processAlert("stored-token123", "1.2.3.4", "TestAgent/1.0", "GET", "/c/stored-token123", "2024-01-01T00:00:00Z", false)
+	logs := captureLogs(t, func() {
+		s.processAlert(tokenID, "1.2.3.4", "TestAgent/1.0", "GET", "/c/"+tokenID, "2024-01-01T00:00:00Z", false)
+	})
+	if strings.Contains(logs, tokenID) || strings.Contains(logs, "1.2.3.4") {
+		t.Fatalf("processAlert log exposed token/IP: %q", logs)
+	}
+	if !strings.Contains(logs, "CANARY_FIRED token=*** ip=***") {
+		t.Fatalf("processAlert log did not include redacted canary marker: %q", logs)
+	}
 
-	events, err := s.db.getEvents("stored-token123")
+	events, err := s.db.getEvents(tokenID)
 	if err != nil {
 		t.Fatalf("getEvents: %v", err)
 	}
@@ -103,6 +162,29 @@ func TestHandleCanary_storesEvent(t *testing.T) {
 	}
 	if events[0].UserAgent != "TestAgent/1.0" {
 		t.Errorf("UserAgent = %q, want TestAgent/1.0", events[0].UserAgent)
+	}
+}
+
+func TestHandleCanary_unregisteredTokenDoesNotStoreEvent(t *testing.T) {
+	s := testServer(t)
+	const tokenID = "some-unregistered-token-abc123"
+
+	logs := captureLogs(t, func() {
+		s.processAlert(tokenID, "1.2.3.4", "TestAgent/1.0", "GET", "/c/"+tokenID, "2024-01-01T00:00:00Z", false)
+	})
+	if strings.Contains(logs, tokenID) || strings.Contains(logs, "1.2.3.4") {
+		t.Fatalf("unregistered token log exposed token/IP: %q", logs)
+	}
+	if !strings.Contains(logs, "UNREGISTERED token=*** ip=***") {
+		t.Fatalf("unregistered token log did not include redacted marker: %q", logs)
+	}
+
+	events, err := s.db.getEvents(tokenID)
+	if err != nil {
+		t.Fatalf("getEvents: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("unregistered token stored %d event(s), want 0", len(events))
 	}
 }
 

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -378,7 +378,7 @@ func clientIP(r *http.Request, trustedProxyNets []*net.IPNet) string {
 		if ip := firstForwardedIP(r.Header.Get("X-Forwarded-For")); ip != "" {
 			return ip
 		}
-		if ip := strings.TrimSpace(r.Header.Get("X-Real-Ip")); ip != "" {
+		if ip := validHeaderIP(r.Header.Get("X-Real-Ip")); ip != "" {
 			return ip
 		}
 	}
@@ -401,7 +401,15 @@ func firstForwardedIP(xff string) string {
 	if len(parts) == 0 {
 		return ""
 	}
-	return strings.TrimSpace(parts[0])
+	return validHeaderIP(parts[0])
+}
+
+func validHeaderIP(value string) string {
+	ip := strings.TrimSpace(value)
+	if ip == "" || net.ParseIP(ip) == nil {
+		return ""
+	}
+	return ip
 }
 
 func parseTrustedProxyCIDRs(cidrs []string) ([]*net.IPNet, error) {


### PR DESCRIPTION
## Summary
- Redact self-hosted callback logs so token IDs and client IPs are not written to process logs.
- Drop unregistered real-token callbacks before event persistence to match managed Worker behavior and reduce probe-spam noise.
- Validate trusted proxy forwarded IP headers before storing callback metadata.

## Tests
- go test -count=1 ./...
- go test -race -count=1 ./...
- go vet ./...
- go build ./...
- (cd worker && npm test)
- (cd worker && npm audit --audit-level=moderate)
- govulncheck ./...
- git diff --check