### PR TITLE
feat: add proof report output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning: [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+### Added
+- `snare prove --report` and `snare prove --format json` for first-success proof reports that capture precision trigger commands, observed callbacks, status, and cleanup commands.
+
 ## [0.2.0] - 2026-05-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ By default, `snare arm` uses **precision mode**: only `awsproc`, `ssh`, and `k8s
     snare scan     verify planted files are present and unchanged
     snare doctor   confidence screen: config, API, ownership, and test health
     snare repair   re-sync registrations safely if doctor finds drift
-    snare prove    print safe precision trigger commands (awsproc/ssh/k8s)
+    snare prove --run --report   safely trigger precision canaries and print a proof report
     snare events   view real hits when one arrives
 ```
 
-Immediately after arming, `snare status` will usually show `never fired`. That is expected: it means Snare has not recorded a real callback for that canary yet. Use `snare scan` for local file integrity, `snare doctor` for setup health, and `snare test` if you want to fire a synthetic callback and check your webhook destination.
+Immediately after arming, `snare status` will usually show `never fired`. That is expected: it means Snare has not recorded a real callback for that canary yet. Use `snare scan` for local file integrity, `snare doctor` for setup health, and `snare prove --run --report` when you want to safely trigger the precision canaries and produce a first-success report.
 
 To arm all canary types (including dotenv-based ones like OpenAI, Anthropic, etc.):
 
@@ -123,6 +123,8 @@ snare status                 # show active canaries + event state
 snare repair                 # re-register active tokens + run a live test check
 snare sync                   # alias for snare repair
 snare prove [--type <t>]     # guided precision trigger commands (awsproc/ssh/k8s)
+snare prove --run --report   # execute safe triggers and print a proof report
+snare prove --format json    # machine-readable proof report output
 snare events                 # fetch recent alert history from snare.sh
 snare events --summary       # ASN/UA distribution across all canaries
 snare scan                   # check canary integrity on disk
@@ -160,6 +162,7 @@ After `snare arm`, the expected healthy loop is:
 - `snare events` shows real hit history; empty output on fresh installs is expected.
 - `snare repair` (or `snare sync`) safely re-registers active tokens and re-tests callback/event readability when drift is detected.
 - `snare prove` prints safe precision trigger commands so you can intentionally prove alerts fire for `awsproc`, `ssh`, and `k8s`.
+- `snare prove --run --report` executes those triggers, confirms callbacks through the events API, and prints a compact proof report with cleanup commands.
 
 Important state distinction:
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -126,7 +126,7 @@ Commands:
   snare scan                   check canary integrity on disk
   snare repair                 safely re-sync token registrations + test health
   snare sync                   alias for snare repair
-  snare prove [flags]          guided precision canary trigger proof (awsproc/ssh/k8s)
+  snare prove [flags]          guided precision proof with optional report output
   snare events                 fetch recent alert events from snare.sh
   snare test                   fire a test alert to verify your webhook
   snare doctor [--test]        confidence screen: config, API, canaries, ownership, callbacks
@@ -147,6 +147,12 @@ Flags (arm):
   --all                        plant all canary types including dotenv-based ones
   --select                     interactive checklist to pick which canaries to arm
   --dry-run                    show what would be planted without writing
+
+Flags (prove):
+  --type <type>                precision canary type: awsproc, ssh, or k8s
+  --run                        execute safe trigger commands and verify callbacks
+  --report                     print a first-success proof report
+  --format text|json           output format for proof reports (json implies --report)
 
 Flags (plant):
   --label <name>               name your canary (e.g. prod-admin-legacy-2024) — defaults to hostname

--- a/internal/cli/cmd_arming.go
+++ b/internal/cli/cmd_arming.go
@@ -470,7 +470,7 @@ Naming tip:
 	fmt.Println("    snare scan     verify planted files are present and unchanged")
 	fmt.Println("    snare doctor   confidence screen: config, API, ownership, and test health")
 	fmt.Println("    snare repair   re-sync registrations safely if doctor finds drift")
-	fmt.Println("    snare prove    print safe precision trigger commands (awsproc/ssh/k8s)")
+	fmt.Println("    snare prove --run --report   safely trigger precision canaries and print a proof report")
 	fmt.Println("    snare events   view real hits when one arrives")
 	fmt.Println("  Run `snare disarm` to remove everything.")
 }

--- a/internal/cli/cmd_confidence.go
+++ b/internal/cli/cmd_confidence.go
@@ -54,6 +54,39 @@ type precisionProofRecipe struct {
 	Binary   string
 }
 
+type proofReport struct {
+	Version     int                `json:"version"`
+	GeneratedAt string             `json:"generated_at"`
+	DeviceID    string             `json:"device_id"`
+	Mode        string             `json:"mode"`
+	RanProofs   bool               `json:"ran_proofs"`
+	Summary     proofReportSummary `json:"summary"`
+	Proofs      []proofReportEntry `json:"proofs"`
+	NextSteps   []string           `json:"next_steps"`
+}
+
+type proofReportSummary struct {
+	Total  int `json:"total"`
+	Passed int `json:"passed"`
+	Failed int `json:"failed"`
+	NotRun int `json:"not_run"`
+}
+
+type proofReportEntry struct {
+	Type        string `json:"type"`
+	Tier        string `json:"tier"`
+	TokenID     string `json:"token_id"`
+	Label       string `json:"label,omitempty"`
+	Path        string `json:"path"`
+	Command     string `json:"command"`
+	Expected    string `json:"expected"`
+	Trigger     string `json:"trigger"`
+	Status      string `json:"status"`
+	ObservedAt  string `json:"observed_at,omitempty"`
+	Error       string `json:"error,omitempty"`
+	NextCommand string `json:"next_command"`
+}
+
 func cmdDoctor(args []string) {
 	if hasFlag(args, "--help") || hasFlag(args, "-h") {
 		fmt.Print(`snare doctor — confidence checks for first-run trust
@@ -380,19 +413,38 @@ func cmdProve(args []string) {
 		fmt.Print(`snare prove — guided precision canary proof commands
 
 Usage:
-  snare prove [--type awsproc|ssh|k8s] [--run]
+  snare prove [--type awsproc|ssh|k8s] [--run] [--report] [--format text|json]
 
 Default behavior:
   Prints exact safe trigger commands for active precision canaries.
 
 With --run:
   Executes the trigger command and confirms a new real callback is readable.
+
+With --report:
+  Prints a first-success proof report with commands, observed callbacks, and next steps.
+
+With --format json:
+  Emits only the proof report as JSON. Implies --report.
 `)
 		return
 	}
 
 	typeFilter := flagValue(args, "--type")
 	run := hasFlag(args, "--run")
+	reportRequested := hasFlag(args, "--report")
+	format := flagValue(args, "--format")
+	if format == "" {
+		format = "text"
+	}
+	format = strings.ToLower(format)
+	if format != "text" && format != "json" {
+		fatal(fmt.Errorf("unsupported --format %q (expected text or json)", format))
+	}
+	jsonOutput := format == "json"
+	if jsonOutput {
+		reportRequested = true
+	}
 
 	if typeFilter != "" && !isPrecisionCanaryType(typeFilter) {
 		fatal(fmt.Errorf("unsupported --type %q (expected awsproc, ssh, or k8s)", typeFilter))
@@ -431,75 +483,234 @@ With --run:
 		fatal(fmt.Errorf("no runnable precision canary proofs found"))
 	}
 
-	fmt.Println()
-	fmt.Println("  snare prove — precision proof flow")
-	fmt.Println()
-	for _, recipe := range recipes {
-		fmt.Printf("  %-8s %s\n", recipe.Canary.Type, shortTokenID(recipe.Canary.ID))
-		fmt.Printf("    command: %s\n", recipe.Command)
-		fmt.Printf("    expect:  %s\n", recipe.Expected)
+	report := buildProofReport(cfg, recipes, run)
+
+	if !jsonOutput {
 		fmt.Println()
+		fmt.Println("  snare prove — precision proof flow")
+		fmt.Println()
+		for _, recipe := range recipes {
+			fmt.Printf("  %-8s %s\n", recipe.Canary.Type, shortTokenID(recipe.Canary.ID))
+			fmt.Printf("    command: %s\n", recipe.Command)
+			fmt.Printf("    expect:  %s\n", recipe.Expected)
+			fmt.Println()
+		}
 	}
 
 	if !run {
-		fmt.Println("  These commands intentionally trigger active precision canaries.")
-		fmt.Println("  Add `--run` to execute them and verify callbacks end-to-end.")
-		fmt.Println()
+		if !jsonOutput {
+			fmt.Println("  These commands intentionally trigger active precision canaries.")
+			fmt.Println("  Add `--run` to execute them and verify callbacks end-to-end.")
+			fmt.Println()
+		}
+		if reportRequested {
+			if jsonOutput {
+				printProofReportJSON(report)
+			} else {
+				printProofReport(report)
+			}
+		}
 		return
 	}
 
 	failures := 0
-	for _, recipe := range recipes {
+	for i, recipe := range recipes {
 		before := probeTokenEvents(cfg, recipe.Canary.ID)
 		if before.AuthFailed {
-			fmt.Fprintf(os.Stderr, "  ✗ %-8s auth failed before proof — run `snare repair`\n", recipe.Canary.Type)
+			msg := "auth failed before proof — run `snare repair`"
+			report.Proofs[i].Status = "failed"
+			report.Proofs[i].Error = msg
+			fmt.Fprintf(os.Stderr, "  ✗ %-8s %s\n", recipe.Canary.Type, msg)
 			failures++
 			continue
 		}
 		if before.Unregistered {
-			fmt.Fprintf(os.Stderr, "  ✗ %-8s token is unregistered — run `snare repair`\n", recipe.Canary.Type)
+			msg := "token is unregistered — run `snare repair`"
+			report.Proofs[i].Status = "failed"
+			report.Proofs[i].Error = msg
+			fmt.Fprintf(os.Stderr, "  ✗ %-8s %s\n", recipe.Canary.Type, msg)
 			failures++
 			continue
 		}
 		if before.Unavailable {
-			fmt.Fprintf(os.Stderr, "  ✗ %-8s events API unavailable — run `snare doctor`\n", recipe.Canary.Type)
+			msg := "events API unavailable — run `snare doctor`"
+			report.Proofs[i].Status = "failed"
+			report.Proofs[i].Error = msg
+			fmt.Fprintf(os.Stderr, "  ✗ %-8s %s\n", recipe.Canary.Type, msg)
 			failures++
 			continue
 		}
 
 		if _, err := exec.LookPath(recipe.Binary); err != nil {
-			fmt.Fprintf(os.Stderr, "  ✗ %-8s missing `%s` binary; run the printed command manually when installed\n", recipe.Canary.Type, recipe.Binary)
+			msg := fmt.Sprintf("missing `%s` binary; run the printed command manually when installed", recipe.Binary)
+			report.Proofs[i].Status = "failed"
+			report.Proofs[i].Error = msg
+			fmt.Fprintf(os.Stderr, "  ✗ %-8s %s\n", recipe.Canary.Type, msg)
 			failures++
 			continue
 		}
 
 		baseline := countEventsByKind(before.Events, false)
-		fmt.Printf("  Running %-8s proof...\n", recipe.Canary.Type)
+		if !jsonOutput {
+			fmt.Printf("  Running %-8s proof...\n", recipe.Canary.Type)
+		}
 		if err := runProofCommand(recipe.Command, 15*time.Second); err != nil {
-			fmt.Fprintf(os.Stderr, "    ✗ trigger command failed: %v\n", err)
+			msg := fmt.Sprintf("trigger command failed: %v", err)
+			report.Proofs[i].Status = "failed"
+			report.Proofs[i].Error = msg
+			fmt.Fprintf(os.Stderr, "    ✗ %s\n", msg)
 			failures++
 			continue
 		}
 
 		ts, err := waitForEventCountAbove(cfg, recipe.Canary.ID, baseline, false, 8*time.Second)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "    ✗ callback not observed: %v\n", err)
+			msg := fmt.Sprintf("callback not observed: %v", err)
+			report.Proofs[i].Status = "failed"
+			report.Proofs[i].Error = msg
+			fmt.Fprintf(os.Stderr, "    ✗ %s\n", msg)
 			failures++
 			continue
 		}
 		if ts == "" {
 			ts = "just now"
 		}
-		fmt.Printf("    ✓ callback observed at %s\n", ts)
+		report.Proofs[i].Status = "passed"
+		report.Proofs[i].ObservedAt = ts
+		if !jsonOutput {
+			fmt.Printf("    ✓ callback observed at %s\n", ts)
+		}
+	}
+	finalizeProofReport(&report)
+
+	if reportRequested {
+		if jsonOutput {
+			printProofReportJSON(report)
+		} else {
+			printProofReport(report)
+		}
 	}
 
-	fmt.Println()
+	if !jsonOutput {
+		fmt.Println()
+	}
 	if failures > 0 {
-		fmt.Printf("  %d proof step(s) failed. Use `snare doctor --test` and `snare repair` for diagnostics.\n\n", failures)
+		if !jsonOutput {
+			fmt.Printf("  %d proof step(s) failed. Use `snare doctor --test` and `snare repair` for diagnostics.\n\n", failures)
+		}
 		os.Exit(1)
 	}
-	fmt.Println("  ✓ Precision proof complete. Alerts are firing as expected.")
+	if !jsonOutput {
+		fmt.Println("  ✓ Precision proof complete. Alerts are firing as expected.")
+		fmt.Println()
+	}
+}
+
+func buildProofReport(cfg *config.Config, recipes []precisionProofRecipe, run bool) proofReport {
+	status := "not-run"
+	if run {
+		status = "pending"
+	}
+
+	proofs := make([]proofReportEntry, 0, len(recipes))
+	for _, recipe := range recipes {
+		proofs = append(proofs, proofReportEntry{
+			Type:        recipe.Canary.Type,
+			Tier:        "precision",
+			TokenID:     recipe.Canary.ID,
+			Label:       recipe.Canary.Label,
+			Path:        recipe.Canary.Path,
+			Command:     recipe.Command,
+			Expected:    recipe.Expected,
+			Trigger:     precisionTriggerDescription(recipe.Canary.Type),
+			Status:      status,
+			NextCommand: "snare teardown --token " + recipe.Canary.ID,
+		})
+	}
+
+	report := proofReport{
+		Version:     1,
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		DeviceID:    cfg.DeviceID,
+		Mode:        "precision",
+		RanProofs:   run,
+		Proofs:      proofs,
+		NextSteps: []string{
+			"snare events",
+			"snare doctor",
+			"snare disarm",
+		},
+	}
+	finalizeProofReport(&report)
+	return report
+}
+
+func finalizeProofReport(report *proofReport) {
+	report.Summary = proofReportSummary{Total: len(report.Proofs)}
+	for _, proof := range report.Proofs {
+		switch proof.Status {
+		case "passed":
+			report.Summary.Passed++
+		case "failed":
+			report.Summary.Failed++
+		case "not-run", "pending":
+			report.Summary.NotRun++
+		}
+	}
+}
+
+func printProofReport(report proofReport) {
+	fmt.Println("  Proof report")
+	fmt.Printf("    device:    %s\n", report.DeviceID)
+	fmt.Printf("    mode:      %s\n", report.Mode)
+	fmt.Printf("    generated: %s\n", report.GeneratedAt)
+	fmt.Printf("    summary:   %d total, %d passed, %d failed, %d not run\n",
+		report.Summary.Total, report.Summary.Passed, report.Summary.Failed, report.Summary.NotRun)
 	fmt.Println()
+
+	for _, proof := range report.Proofs {
+		fmt.Printf("    %-8s %-7s %s\n", proof.Type, proof.Status, shortTokenID(proof.TokenID))
+		fmt.Printf("      tier:     %s\n", proof.Tier)
+		fmt.Printf("      trigger:  %s\n", proof.Trigger)
+		fmt.Printf("      path:     %s\n", proof.Path)
+		fmt.Printf("      command:  %s\n", proof.Command)
+		fmt.Printf("      expect:   %s\n", proof.Expected)
+		if proof.ObservedAt != "" {
+			fmt.Printf("      observed: %s\n", proof.ObservedAt)
+		}
+		if proof.Error != "" {
+			fmt.Printf("      error:    %s\n", proof.Error)
+		}
+		fmt.Printf("      cleanup:  %s\n", proof.NextCommand)
+		fmt.Println()
+	}
+
+	fmt.Println("    next:")
+	for _, step := range report.NextSteps {
+		fmt.Printf("      %s\n", step)
+	}
+	fmt.Println()
+}
+
+func printProofReportJSON(report proofReport) {
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		fatal(fmt.Errorf("encoding proof report: %w", err))
+	}
+	fmt.Println(string(data))
+}
+
+func precisionTriggerDescription(t string) string {
+	switch t {
+	case "awsproc":
+		return "AWS credential_process executes during SDK credential resolution before an AWS API call"
+	case "ssh":
+		return "SSH ProxyCommand executes before the fake host connection is established"
+	case "k8s":
+		return "kubeconfig server/exec credential path is contacted by kubectl or a Kubernetes SDK"
+	default:
+		return "active precision canary use"
+	}
 }
 
 func probeTokenEvents(cfg *config.Config, tokenID string) tokenProbeResult {

--- a/internal/cli/confidence_test.go
+++ b/internal/cli/confidence_test.go
@@ -617,6 +617,51 @@ Host proof-bastion
 			t.Fatalf("prove output missing %q:\n%s", want, stdout)
 		}
 	}
+
+	stdout, stderr, exitCode = runSnare(t, home, "prove", "--format", "json")
+	if exitCode != 0 {
+		t.Fatalf("prove --format json should succeed:\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+	if strings.Contains(stdout, "snare prove — precision proof flow") {
+		t.Fatalf("json report should not include human proof output:\n%s", stdout)
+	}
+	var report struct {
+		Version   int    `json:"version"`
+		DeviceID  string `json:"device_id"`
+		Mode      string `json:"mode"`
+		RanProofs bool   `json:"ran_proofs"`
+		Summary   struct {
+			Total  int `json:"total"`
+			Passed int `json:"passed"`
+			Failed int `json:"failed"`
+			NotRun int `json:"not_run"`
+		} `json:"summary"`
+		Proofs []struct {
+			Type        string `json:"type"`
+			Tier        string `json:"tier"`
+			Status      string `json:"status"`
+			Command     string `json:"command"`
+			Trigger     string `json:"trigger"`
+			NextCommand string `json:"next_command"`
+		} `json:"proofs"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &report); err != nil {
+		t.Fatalf("json report did not parse: %v\n%s", err, stdout)
+	}
+	if report.Version != 1 || report.DeviceID != deviceID || report.Mode != "precision" || report.RanProofs {
+		t.Fatalf("unexpected report header: %+v", report)
+	}
+	if report.Summary.Total != 3 || report.Summary.NotRun != 3 || report.Summary.Passed != 0 || report.Summary.Failed != 0 {
+		t.Fatalf("unexpected report summary: %+v", report.Summary)
+	}
+	if len(report.Proofs) != 3 {
+		t.Fatalf("expected 3 proof entries, got %d", len(report.Proofs))
+	}
+	for _, proof := range report.Proofs {
+		if proof.Tier != "precision" || proof.Status != "not-run" || proof.Command == "" || proof.Trigger == "" || !strings.HasPrefix(proof.NextCommand, "snare teardown --token ") {
+			t.Fatalf("unexpected proof entry: %+v", proof)
+		}
+	}
 }
 
 func TestProveRunUsesManifestPathsAndObservesCallbacks(t *testing.T) {
@@ -716,13 +761,13 @@ exit 1
 
 	stdout, stderr, exitCode = runSnareWithEnv(t, home, map[string]string{
 		"PATH": binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
-	}, "prove", "--run")
+	}, "prove", "--run", "--report")
 	if exitCode != 0 {
-		t.Fatalf("prove --run should observe callbacks:\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+		t.Fatalf("prove --run --report should observe callbacks:\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
 	}
-	for _, want := range []string{"Precision proof complete", "awsproc", "ssh", "k8s"} {
+	for _, want := range []string{"Precision proof complete", "Proof report", "summary:   3 total, 3 passed, 0 failed, 0 not run", "observed:", "awsproc", "ssh", "k8s"} {
 		if !strings.Contains(stdout, want) {
-			t.Fatalf("prove --run output missing %q:\n%s", want, stdout)
+			t.Fatalf("prove --run --report output missing %q:\n%s", want, stdout)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Add `snare prove --report` for first-success proof reports covering precision canary commands, observed callbacks, status, and cleanup commands.
- Add `snare prove --format json` for machine-readable report output, with JSON mode implying report output.
- Update first-run docs, CLI help, and changelog to point users toward the proof report workflow.

## Tests
- `git diff --check`
- `go test ./... -count=1`
- `cd worker && npm ci && npm test -- --run`