### PR TITLE
chore: prepare v0.3.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,17 @@ Versioning: [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-26
+
 ### Added
+- `snare prove` for guided precision canary proof commands covering `awsproc`, `ssh`, and `k8s` canaries.
+- `snare prove --run` to execute safe precision triggers and confirm callback visibility through the events API.
 - `snare prove --report` and `snare prove --format json` for first-success proof reports that capture precision trigger commands, observed callbacks, status, and cleanup commands.
+
+## [0.2.1] - 2026-05-23
+
+### Fixed
+- Hardened release archives and self-hosted deployment packaging.
 
 ## [0.2.0] - 2026-05-01
 


### PR DESCRIPTION
## Summary
- Add a v0.3.0 changelog section for the `snare prove` first-success proof flow.
- Add the missing v0.2.1 changelog section for release packaging hardening.
- Leave `Unreleased` empty so the next public release notes reflect the installable CLI state.

## Tests
- `git diff --check`
- `go test ./... -count=1`
- `go build -ldflags='-s -w -X main.version=v0.3.0' -o /tmp/snare-v0.3.0-candidate ./cmd/snare`
- `/tmp/snare-v0.3.0-candidate --version`
- `/tmp/snare-v0.3.0-candidate prove --help`
