### PR TITLE
docs: add enterprise evaluation guide

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -82,7 +82,7 @@ Device IDs are server-assigned via `POST /api/devices` — clients cannot choose
 3. Fire all webhooks in parallel via `Promise.allSettled`
 4. Failures logged to CF Workers Logs but don't affect the response
 
-Outbound webhook requests include `X-Snare-Signature: sha256=<hmac>` when `WEBHOOK_SIGNING_SECRET` CF secret is configured. Receivers can verify alerts came from snare.sh.
+Outbound webhook requests include `X-Snare-Signature: sha256=<hmac>` when the Cloudflare Worker `WEBHOOK_SIGNING_SECRET` secret is configured. Receivers can verify alerts came from the configured Snare callback deployment.
 
 **Supported webhook formats:** Discord (embed), Slack (attachment), Telegram (HTML), generic JSON (`event: "canary.fired"`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning: [Semantic Versioning](https://semver.org/)
 ### Added
 - `snare prove --output <path>` for writing proof reports as shareable artifacts.
 - `snare prove --redact` for share-safe proof reports that remove device IDs, token IDs, labels, cleanup tokens, and absolute local paths.
+- Enterprise evaluation, self-hosting, and SIEM integration guides for security-review-friendly pilots.
+- `snare serve --help` for self-hosted callback server flag discovery.
 
 ### Changed
 - Proof reports now include event visibility, observed callback latency, and explicit “what this proves” / “what this does not prove” sections.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ snare arm --all --webhook https://discord.com/api/webhooks/YOUR/WEBHOOK
 
 Supported webhook destinations: Discord, Slack, Telegram, or any endpoint that accepts JSON. Treat webhook URLs as secrets — don't commit, screenshot, or share them.
 
+Evaluating Snare for a team or lab? Start with the [enterprise evaluation guide](docs/enterprise-evaluation.md), then wire alerts to your SIEM with the [webhook integration docs](docs/integrations/generic-webhook.md).
+
 ---
 
 ## Commands
@@ -258,7 +260,9 @@ Each alert includes:
 - User agent (identifies the exact SDK: `Boto3/1.34.46`, `kubectl/v1.35.1`, etc.)
 - "Likely AI agent" flag when the request comes from cloud infrastructure
 
-Alerts are signed with `X-Snare-Signature` (HMAC-SHA256) so you can verify they came from snare.sh.
+Alerts are signed with `X-Snare-Signature` (HMAC-SHA256) when webhook signing is configured, so receivers can verify the sender.
+
+See [generic webhooks](docs/integrations/generic-webhook.md), [Splunk](docs/integrations/splunk.md), [Datadog](docs/integrations/datadog.md), and [Microsoft Sentinel](docs/integrations/sentinel.md) for SIEM integration patterns.
 
 ---
 
@@ -302,27 +306,29 @@ Fake credential content lives locally in `~/.snare/manifest.json` (0600) and is 
 
 ## Self-hosting
 
-The Cloudflare Worker is open source in this repo (`worker/`). Deploy it to your own account:
+Use self-hosting when you need a custom callback domain, full network-layer control, private retention, or SIEM relay behavior. The repo includes both the Cloudflare Worker source (`worker/`) and a standalone `snare serve` path with Docker Compose.
+
+Quick standalone server:
 
 ```sh
-cd worker
-npx wrangler deploy
+SNARE_DASHBOARD_TOKEN="$(openssl rand -hex 32)" \
+  snare serve --port 8080 --db /var/lib/snare/snare.db
 ```
 
-Set `WEBHOOK_URLS` as a Cloudflare Worker secret for alert delivery. Set `WEBHOOK_SIGNING_SECRET` to sign outbound requests.
-
-To point canaries at your own server instead of snare.sh, edit `callback_base` in `~/.snare/config.json` after `snare init`.
-
-`snare serve` requires `--dashboard-token` (or `SNARE_DASHBOARD_TOKEN`) to protect the dashboard. Generate one with `openssl rand -hex 32`.
-
-Docker Compose can use `.env.example` as a starting point:
+Quick Docker Compose path:
 
 ```sh
-cp .env.example .env
-SNARE_DASHBOARD_TOKEN="$(openssl rand -hex 32)" docker compose up -d
+{
+  echo "SNARE_DASHBOARD_TOKEN=$(openssl rand -hex 32)"
+  echo "SNARE_PORT=8080"
+} > .env
+docker compose up -d
+curl -fsS http://localhost:8080/health
 ```
 
-> **Important:** Only expose `snare serve` behind a reverse proxy you control (nginx, Caddy, Cloudflare Tunnel). Never bind directly to a public interface. By default the server ignores `X-Forwarded-For` and `X-Real-IP`. If you want real client IP attribution behind a trusted proxy, set `--trusted-proxy <cidr,...>` to the proxy network(s) that are allowed to supply those headers.
+Only expose `snare serve` behind a reverse proxy you control. By default the server ignores `X-Forwarded-For` and `X-Real-IP`; set `--trusted-proxy <cidr,...>` only for proxy networks that are allowed to supply those headers.
+
+See the [self-hosting guide](docs/self-hosting.md) for reverse proxy, backup, upgrade, Cloudflare Worker, and client `callback_base` steps.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,6 +35,8 @@ Out of scope:
 
 **Privacy guarantee:** The `/c/{token}` callback endpoint never reads, stores, or forwards request bodies. Only header-derived metadata is stored (IP, user agent, timestamp, ASN). This applies to the managed snare.sh worker. Self-hosted deployments are controlled by the operator.
 
+For a team/security review checklist covering data flow, files touched, proof artifacts, SIEM routing, and cleanup, see [docs/enterprise-evaluation.md](docs/enterprise-evaluation.md).
+
 **Device secret:** The CLI generates a 256-bit device secret at `~/.snare/config.json` (0600 permissions). This secret authenticates API calls to snare.sh. If compromised, run `snare rotate` immediately.
 
 ## Supported Versions

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+# Snare docs
+
+These docs are written for security engineers evaluating, piloting, or operating Snare beyond a single local test.
+
+- [Enterprise evaluation](enterprise-evaluation.md) — data flow, files touched, safe pilot checklist, proof artifact workflow, and limitations.
+- [Self-hosting](self-hosting.md) — Docker Compose, `snare serve`, Cloudflare Worker deployment notes, reverse proxy guidance, backups, and upgrades.
+- [Generic webhooks](integrations/generic-webhook.md) — event schema, signature verification, and relay guidance.
+- [Splunk integration](integrations/splunk.md) — Splunk HEC relay pattern and field mapping.
+- [Datadog integration](integrations/datadog.md) — direct Logs intake and monitor examples.
+- [Microsoft Sentinel integration](integrations/sentinel.md) — Log Analytics relay pattern and KQL examples.

--- a/docs/enterprise-evaluation.md
+++ b/docs/enterprise-evaluation.md
@@ -1,0 +1,155 @@
+# Enterprise evaluation guide
+
+Snare is intentionally small: a CLI plants credential and tool-use tripwires, callbacks produce alert metadata, and the operator can prove and remove the tripwires. This guide is for security engineers who need to evaluate Snare safely before using it in a lab, developer fleet, CI environment, or AI-agent pilot.
+
+## What Snare does and does not do
+
+Snare detects active use of planted fake credentials and tool configurations. It is not a prompt-injection firewall, EDR, DLP tool, or policy enforcement engine.
+
+Snare is useful when you want to know whether an agent, scanner, script, or human attacker tried to use a sensitive-looking local capability such as an AWS profile, SSH host, kube context, package registry, or SDK endpoint override.
+
+## Recommended safe pilot
+
+Start with the default precision canaries (`awsproc`, `ssh`, `k8s`). They are designed to stay quiet during normal work and fire only when the planted fake profile, host, or context is actively used.
+
+```sh
+# 1. Preview local file changes without writing canaries.
+snare arm --dry-run
+
+# 2. Arm precision-mode canaries and send alerts to an existing destination.
+snare arm --webhook https://example.com/snare-webhook
+
+# 3. Confirm local state and expected quiet state.
+snare status
+snare scan
+snare doctor
+
+# 4. Run an end-to-end test callback and verify event readability.
+snare doctor --test
+
+# 5. Safely trigger precision canaries and write a redacted proof artifact.
+snare prove --run --report --redact --format json --output proof.json
+
+# 6. Review recent callback evidence.
+snare events
+
+# 7. Remove canaries and local Snare config when the pilot is done.
+snare disarm --purge
+```
+
+A fresh canary showing `never fired` can be healthy. Use `snare scan`, `snare doctor`, and `snare prove` to distinguish a healthy quiet canary from a registration or readability problem.
+
+## What files Snare touches
+
+`snare arm` defaults to precision mode and only plants `awsproc`, `ssh`, and `k8s` canaries. `snare arm --all` expands to every canary type.
+
+| Scope | Examples | Notes |
+|---|---|---|
+| Local Snare state | `~/.snare/config.json`, `~/.snare/manifest.json` | Created with restrictive permissions. Manifest records exact bytes written for safe teardown. |
+| Precision canaries | `~/.aws/config`, `~/.ssh/config`, `~/.kube/<name>.yaml` | Default mode. Designed to fire on active use, not passive reads. |
+| Package/tool canaries | `~/.npmrc`, `~/.config/pip/pip.conf`, `~/.gitconfig`, `~/.terraformrc`, `~/.docker/config.json` | Use selectively. Some package-manager canaries may fire during normal developer workflows. |
+| SDK/app canaries | dotenv files and vendor config files for OpenAI, Anthropic, GCP, Azure, GitHub, Stripe, Hugging Face, MCP, and generic endpoints | These depend on how the target agent or tool consumes local config. |
+
+Teardown is content-matched: Snare removes the exact bytes it wrote and does not rewrite unrelated credentials in the same file. Use `snare teardown --dry-run`, `snare disarm`, or `snare disarm --purge` during evaluation cleanup.
+
+## Data flow
+
+### Managed `snare.sh`
+
+1. The CLI creates a local device secret and registers token metadata with `snare.sh`.
+2. A planted canary contains a callback URL such as `https://snare.sh/c/<token>`.
+3. If the fake credential/tool path is used, the SDK or tool requests the callback URL.
+4. The callback service stores metadata and optionally forwards an alert to your webhook destination.
+5. The CLI reads recent events with the local device secret.
+
+### What leaves the machine
+
+| Flow | Data |
+|---|---|
+| Registration API | Token ID, device ID, canary type, label, webhook routing metadata. |
+| Events API | Token ID in the URL and bearer device secret for authenticated reads. |
+| Canary callback | Token ID, request path, method, IP, user agent, Cloudflare-derived geography/ASN/bot metadata when using the managed worker. |
+| Webhook delivery | Alert payload containing event metadata. No request body is included. |
+
+Callback handlers intentionally do not read, store, or forward request bodies. This matters because some SDK callbacks can include credential material in HTTP bodies. The application-level privacy guarantee does not mean Cloudflare or other network infrastructure never handles the encrypted network request; self-host if you need full network-layer control.
+
+## Proof artifact workflow
+
+Use proof reports as the shareable evaluation artifact:
+
+```sh
+snare prove --run --report --redact --format json --output proof.json
+```
+
+A useful proof artifact should show:
+
+- which precision canaries were armed;
+- which trigger commands were executed;
+- whether callbacks were visible through the events API;
+- observed callback timestamps and latency where available;
+- cleanup commands;
+- what the proof demonstrates;
+- what the proof does not demonstrate.
+
+Use `--redact` before sharing outside the evaluating machine. Redaction removes raw device IDs, token IDs, labels, cleanup-token values, and local absolute paths.
+
+## Webhooks and SIEMs
+
+Snare can post alerts to Discord, Slack, Telegram, or generic JSON webhook endpoints. For SIEMs that require custom headers, signed requests, or vendor-specific envelope formats, put a small relay in front of the SIEM and have Snare post to the relay.
+
+See:
+
+- [Generic webhooks](integrations/generic-webhook.md)
+- [Splunk](integrations/splunk.md)
+- [Datadog](integrations/datadog.md)
+- [Microsoft Sentinel](integrations/sentinel.md)
+
+## Self-hosting decision
+
+Use managed `snare.sh` for a quick lab. Self-host when you need one or more of the following:
+
+- all callback traffic to stay inside your network or cloud account;
+- a custom callback domain;
+- control over log retention, backup, and alert routing;
+- custom webhook signing or relay behavior;
+- evaluation in a restricted enterprise lab.
+
+See [Self-hosting](self-hosting.md).
+
+## Release and install verification
+
+For production-like pilots, verify the release before installing broadly:
+
+```sh
+cosign verify-blob --bundle checksums.txt.bundle checksums.txt
+sha256sum -c checksums.txt
+```
+
+Then smoke-test the binary in a temporary install directory before deploying to endpoints:
+
+```sh
+snare --version
+snare arm --help
+snare doctor --help
+snare prove --help
+```
+
+## Known limitations to include in review
+
+- Snare detects use of planted tripwires; it does not prevent compromise.
+- `~/.snare/manifest.json` records canary locations so Snare can safely remove them. A local attacker who reads it can identify bait.
+- Public callback domains can be fingerprinted. Use self-hosting or a custom callback domain when that matters.
+- Some canary types are intentionally noisier than the precision defaults and should be selected deliberately.
+- Managed mode depends on the availability and policy of the hosted callback service and its network provider.
+- Webhook URLs are secrets and should be handled like credentials.
+
+## Evaluation checklist
+
+- [ ] `snare arm --dry-run` output reviewed by a security engineer.
+- [ ] Default precision-mode canaries tested before `--all`.
+- [ ] `snare doctor --test` passes in the target network.
+- [ ] `snare prove --run --report --redact --format json --output proof.json` produces a share-safe artifact.
+- [ ] Alert destination tested and owned by the evaluating team.
+- [ ] Cleanup command verified with `snare disarm --purge` on a pilot host.
+- [ ] SIEM relay or direct integration documented, including secret handling.
+- [ ] Self-hosting decision recorded for callback privacy and custom domain requirements.

--- a/docs/integrations/datadog.md
+++ b/docs/integrations/datadog.md
@@ -1,0 +1,89 @@
+# Datadog integration
+
+Datadog Logs intake can accept the API key in the URL path, so Snare can send generic JSON directly. Use a relay instead if your organization forbids secrets in webhook URLs or requires request signing before ingestion.
+
+## Direct Logs intake
+
+Use the Datadog site that matches your account.
+
+US site example:
+
+```sh
+snare config set webhook 'https://http-intake.logs.datadoghq.com/v1/input/<DATADOG_API_KEY>?ddsource=snare&service=snare&ddtags=team:security,env:pilot'
+snare doctor --test
+```
+
+EU site example:
+
+```sh
+snare config set webhook 'https://http-intake.logs.datadoghq.eu/v1/input/<DATADOG_API_KEY>?ddsource=snare&service=snare&ddtags=team:security,env:pilot'
+snare doctor --test
+```
+
+Treat the configured webhook URL as a secret because it contains the Datadog API key.
+
+## Recommended facets
+
+Create facets or measures from these JSON fields:
+
+| Datadog facet | Snare JSON path |
+|---|---|
+| `@event` | `event` |
+| `@canary_type` | `canary_type` |
+| `@label` | `label` |
+| `@device_id` | `device_id` |
+| `@ip` | `ip` |
+| `@network.org` | `network.org` |
+| `@network.asn` | `network.asn` |
+| `@network.is_cloud` | `network.is_cloud` |
+| `@request.user_agent` | `request.user_agent` |
+| `@is_test` | `is_test` |
+
+## Example log queries
+
+Real canary fires:
+
+```text
+service:snare @event:canary.fired @is_test:false
+```
+
+Cloud-hosted source:
+
+```text
+service:snare @event:canary.fired @is_test:false @network.is_cloud:true
+```
+
+Specific canary type:
+
+```text
+service:snare @canary_type:awsproc @is_test:false
+```
+
+## Monitor example
+
+Create a Logs monitor with query:
+
+```text
+logs("service:snare @event:canary.fired @is_test:false").index("*").rollup("count").last("5m") > 0
+```
+
+Notification text:
+
+```text
+Snare canary fired.
+
+Type: {{log.attributes.canary_type}}
+Label: {{log.attributes.label}}
+IP: {{log.attributes.ip}}
+Network: {{log.attributes.network.org}}
+User-Agent: {{log.attributes.request.user_agent}}
+```
+
+## Validation
+
+```sh
+snare doctor --test
+snare prove --run --report --redact --format json --output proof.json
+```
+
+Confirm `is_test:true` appears for the doctor test and `is_test:false` appears for proof callbacks.

--- a/docs/integrations/generic-webhook.md
+++ b/docs/integrations/generic-webhook.md
@@ -1,0 +1,109 @@
+# Generic webhook integration
+
+Snare sends alert payloads to Discord, Slack, Telegram, or generic JSON webhook endpoints. A generic webhook is any HTTPS endpoint that accepts a JSON `POST` without requiring custom request headers. If your destination requires custom headers, use a small relay.
+
+## Generic payload schema
+
+Generic endpoints receive a JSON object shaped like this:
+
+```json
+{
+  "event": "canary.fired",
+  "is_test": false,
+  "token": "agent-prod-admin-2026-abc123...",
+  "canary_type": "awsproc",
+  "label": "agent-01",
+  "device_id": "dev-...",
+  "timestamp": "2026-03-14T04:07:33.000Z",
+  "ip": "203.0.113.10",
+  "location": {
+    "city": "Council Bluffs",
+    "country": "US"
+  },
+  "network": {
+    "asn": 16509,
+    "org": "Amazon Technologies Inc.",
+    "is_cloud": true
+  },
+  "request": {
+    "method": "GET",
+    "user_agent": "Boto3/1.34.46 md/Botocore#1.34.46",
+    "path": "/c/agent-prod-admin-2026-abc123",
+    "sdk_hints": {
+      "amzSdkRequest": null,
+      "amzTarget": null,
+      "contentType": null,
+      "hasAwsSig": false,
+      "isPost": false
+    }
+  },
+  "bot_score": null,
+  "privacy": "request_body_never_captured"
+}
+```
+
+Callback request bodies are intentionally omitted. Do not build downstream detection logic that expects Snare to forward request bodies.
+
+## Signature verification
+
+Cloudflare Worker deployments can set `WEBHOOK_SIGNING_SECRET`. When configured, the Worker signs outbound webhook bodies with HMAC-SHA256 and sends:
+
+```http
+X-Snare-Signature: sha256=<hex-hmac>
+```
+
+Verify the signature over the exact raw request body before parsing JSON.
+
+```python
+import hmac
+import hashlib
+from flask import Flask, abort, request
+
+app = Flask(__name__)
+SNARE_WEBHOOK_SECRET = b"replace-with-secret"
+
+@app.post("/snare")
+def snare():
+    raw = request.get_data()
+    header = request.headers.get("X-Snare-Signature", "")
+    expected = "sha256=" + hmac.new(SNARE_WEBHOOK_SECRET, raw, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(header, expected):
+        abort(401)
+
+    event = request.get_json(force=True)
+    # Forward to SIEM, alerting system, or queue here.
+    return {"status": "ok"}
+```
+
+If the header is absent, the upstream deployment did not configure webhook signing. Do not silently treat unsigned webhooks as verified.
+
+## Relay guidance
+
+Use a relay when the destination requires any of the following:
+
+- custom authorization headers;
+- request signing;
+- vendor-specific envelope format;
+- private network access;
+- filtering, enrichment, or redaction before ingestion.
+
+A relay should:
+
+1. accept only HTTPS;
+2. verify `X-Snare-Signature` when available;
+3. reject oversized bodies;
+4. parse and validate JSON;
+5. add destination-specific auth headers from server-side secrets;
+6. forward only the fields required by the destination;
+7. return a 2xx only after the downstream write succeeds or is durably queued.
+
+## Testing
+
+Use a live test before depending on an alert path:
+
+```sh
+snare doctor --test
+snare prove --run --report --redact --format json --output proof.json
+```
+
+In the destination, distinguish test events with `is_test: true` from real canary callbacks.

--- a/docs/integrations/sentinel.md
+++ b/docs/integrations/sentinel.md
@@ -1,0 +1,140 @@
+# Microsoft Sentinel integration
+
+Microsoft Sentinel commonly ingests custom application events through Azure Monitor Logs / Log Analytics endpoints that require signed authorization headers. Snare's generic webhook sender does not add custom destination headers, so the recommended pattern is:
+
+```text
+Snare -> HTTPS relay -> Azure Monitor Logs / Sentinel workspace
+```
+
+Use the relay to verify Snare's webhook signature, transform the payload, and sign the Azure request with workspace credentials or a Data Collection Rule endpoint.
+
+## Relay responsibilities
+
+- Terminate TLS.
+- Verify `X-Snare-Signature` when your Snare deployment sets `WEBHOOK_SIGNING_SECRET`.
+- Store Azure credentials in server-side secrets, not in Snare webhook URLs.
+- Preserve the original Snare payload or a documented normalized subset.
+- Return a non-2xx response if Azure ingestion fails.
+
+## Legacy Log Analytics Data Collector relay shape
+
+The older Log Analytics Data Collector API signs each request with the workspace shared key. Use the newer Azure Monitor Logs ingestion API and Data Collection Rules if that is your organization's standard; the same relay pattern applies.
+
+```python
+import base64
+import datetime
+import hashlib
+import hmac
+import json
+import os
+import requests
+from flask import Flask, abort, request
+
+app = Flask(__name__)
+SNARE_WEBHOOK_SECRET = os.environ.get("SNARE_WEBHOOK_SECRET", "").encode()
+WORKSPACE_ID = os.environ["LOG_ANALYTICS_WORKSPACE_ID"]
+SHARED_KEY = os.environ["LOG_ANALYTICS_SHARED_KEY"]
+LOG_TYPE = os.environ.get("LOG_ANALYTICS_LOG_TYPE", "Snare_CL")
+
+
+def verify_snare(raw: bytes) -> None:
+    if not SNARE_WEBHOOK_SECRET:
+        return
+    header = request.headers.get("X-Snare-Signature", "")
+    expected = "sha256=" + hmac.new(SNARE_WEBHOOK_SECRET, raw, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(header, expected):
+        abort(401)
+
+
+def build_signature(date: str, content_length: int, method: str, content_type: str, resource: str) -> str:
+    x_headers = "x-ms-date:" + date
+    string_to_hash = f"{method}\n{content_length}\n{content_type}\n{x_headers}\n{resource}"
+    decoded_key = base64.b64decode(SHARED_KEY)
+    digest = hmac.new(decoded_key, string_to_hash.encode("utf-8"), hashlib.sha256).digest()
+    encoded_hash = base64.b64encode(digest).decode("utf-8")
+    return f"SharedKey {WORKSPACE_ID}:{encoded_hash}"
+
+
+@app.post("/snare")
+def snare_to_sentinel():
+    raw = request.get_data()
+    verify_snare(raw)
+    event = request.get_json(force=True)
+
+    body = json.dumps([event])
+    method = "POST"
+    content_type = "application/json"
+    resource = "/api/logs"
+    date = datetime.datetime.utcnow().strftime("%a, %d %b %Y %H:%M:%S GMT")
+    signature = build_signature(date, len(body), method, content_type, resource)
+
+    url = f"https://{WORKSPACE_ID}.ods.opinsights.azure.com{resource}?api-version=2016-04-01"
+    headers = {
+        "Content-Type": content_type,
+        "Authorization": signature,
+        "Log-Type": LOG_TYPE,
+        "x-ms-date": date,
+    }
+    resp = requests.post(url, data=body, headers=headers, timeout=10)
+    if resp.status_code >= 300:
+        return {"error": "azure ingestion failed", "status": resp.status_code, "body": resp.text[:200]}, 502
+    return {"status": "ok"}
+```
+
+Point Snare at the relay:
+
+```sh
+snare config set webhook https://relay.example.com/snare
+snare doctor --test
+```
+
+## Suggested normalized columns
+
+If you transform events before ingestion, preserve at least:
+
+| Column | Snare JSON path |
+|---|---|
+| `Event` | `event` |
+| `IsTest` | `is_test` |
+| `CanaryType` | `canary_type` |
+| `Label` | `label` |
+| `DeviceId` | `device_id` |
+| `SourceIp` | `ip` |
+| `NetworkOrg` | `network.org` |
+| `NetworkAsn` | `network.asn` |
+| `IsCloud` | `network.is_cloud` |
+| `UserAgent` | `request.user_agent` |
+| `RequestMethod` | `request.method` |
+| `RequestPath` | `request.path` |
+
+## KQL examples
+
+Recent real canary fires:
+
+```kusto
+Snare_CL
+| where Event_s == "canary.fired" and IsTest_b == false
+| project TimeGenerated, CanaryType_s, Label_s, SourceIp_s, NetworkOrg_s, UserAgent_s
+```
+
+Cloud-hosted sources:
+
+```kusto
+Snare_CL
+| where Event_s == "canary.fired" and IsTest_b == false and IsCloud_b == true
+| summarize Count=count() by NetworkOrg_s, CanaryType_s, Label_s
+```
+
+Test coverage by device:
+
+```kusto
+Snare_CL
+| where IsTest_b == true
+| summarize LastTest=max(TimeGenerated), Count=count() by DeviceId_s
+```
+
+## Validation
+
+1. Run `snare doctor --test` and confirm an `IsTest=true` event in Sentinel.
+2. Run `snare prove --run --report --redact --format json --output proof.json` and confirm precision proof callbacks with `IsTest=false`.
+3. Tamper with a signed webhook body in a relay unit test and confirm the relay rejects it.

--- a/docs/integrations/splunk.md
+++ b/docs/integrations/splunk.md
@@ -1,0 +1,114 @@
+# Splunk integration
+
+Splunk HTTP Event Collector (HEC) usually requires an `Authorization: Splunk <token>` header. Snare's generic webhook sender does not add custom destination headers, so the recommended pattern is:
+
+```text
+Snare -> HTTPS relay -> Splunk HEC
+```
+
+The relay keeps the Splunk token server-side, verifies Snare's webhook signature when configured, and wraps the event in a HEC envelope.
+
+## HEC relay example
+
+```python
+import hmac
+import hashlib
+import os
+import time
+import requests
+from flask import Flask, abort, request
+
+app = Flask(__name__)
+SNARE_WEBHOOK_SECRET = os.environ.get("SNARE_WEBHOOK_SECRET", "").encode()
+SPLUNK_HEC_URL = os.environ["SPLUNK_HEC_URL"]  # e.g. https://splunk.example.com:8088/services/collector/event
+SPLUNK_HEC_TOKEN = os.environ["SPLUNK_HEC_TOKEN"]
+SPLUNK_INDEX = os.environ.get("SPLUNK_INDEX", "security")
+
+
+def verify_signature(raw: bytes) -> None:
+    if not SNARE_WEBHOOK_SECRET:
+        return
+    header = request.headers.get("X-Snare-Signature", "")
+    expected = "sha256=" + hmac.new(SNARE_WEBHOOK_SECRET, raw, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(header, expected):
+        abort(401)
+
+
+@app.post("/snare")
+def snare_to_splunk():
+    raw = request.get_data()
+    verify_signature(raw)
+    event = request.get_json(force=True)
+
+    hec_event = {
+        "time": time.time(),
+        "host": event.get("device_id") or "snare",
+        "source": "snare",
+        "sourcetype": "snare:json",
+        "index": SPLUNK_INDEX,
+        "event": event,
+    }
+
+    resp = requests.post(
+        SPLUNK_HEC_URL,
+        headers={"Authorization": f"Splunk {SPLUNK_HEC_TOKEN}"},
+        json=hec_event,
+        timeout=5,
+    )
+    if resp.status_code >= 300:
+        return {"error": "splunk write failed", "status": resp.status_code}, 502
+    return {"status": "ok"}
+```
+
+Run it behind TLS and point Snare at the relay URL:
+
+```sh
+snare config set webhook https://relay.example.com/snare
+snare doctor --test
+```
+
+## Suggested field mapping
+
+Keep the original Snare event under `event` so no context is lost. Common fields to extract in Splunk props/transforms or SPL are:
+
+| Splunk field | Snare JSON path |
+|---|---|
+| `snare_event` | `event.event` |
+| `snare_canary_type` | `event.canary_type` |
+| `snare_label` | `event.label` |
+| `snare_device_id` | `event.device_id` |
+| `src_ip` | `event.ip` |
+| `http_user_agent` | `event.request.user_agent` |
+| `asn` | `event.network.asn` |
+| `asn_org` | `event.network.org` |
+| `is_cloud` | `event.network.is_cloud` |
+| `is_test` | `event.is_test` |
+
+## Example searches
+
+Recent real canary fires:
+
+```spl
+index=security sourcetype=snare:json event.event="canary.fired" event.is_test=false
+| table _time event.canary_type event.label event.ip event.network.org event.request.user_agent
+```
+
+Cloud-hosted sources:
+
+```spl
+index=security sourcetype=snare:json event.network.is_cloud=true event.is_test=false
+| stats count by event.network.org event.canary_type event.label
+```
+
+Noisy tests by host/device:
+
+```spl
+index=security sourcetype=snare:json event.is_test=true
+| stats count max(_time) as last_test by host event.device_id
+```
+
+## Validation
+
+1. Run `snare doctor --test` and confirm a test event lands in Splunk with `event.is_test=true`.
+2. Run `snare prove --run --report --redact --format json --output proof.json` and confirm real precision proof callbacks land with `event.is_test=false`.
+3. Confirm the relay rejects a modified body when `SNARE_WEBHOOK_SECRET` is set.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,158 @@
+# Self-hosting Snare
+
+Snare supports two self-hosting paths:
+
+1. `snare serve` — a standalone HTTP server with SQLite storage and a built-in dashboard.
+2. Cloudflare Worker — the same Worker-style callback path used by managed `snare.sh`, deployed to your own Cloudflare account.
+
+Use self-hosting when you need a custom callback domain, network-layer control, enterprise lab isolation, custom retention, or SIEM relays that require private credentials.
+
+## Option A: Docker Compose with `snare serve`
+
+```sh
+{
+  echo "SNARE_DASHBOARD_TOKEN=$(openssl rand -hex 32)"
+  echo "SNARE_PORT=8080"
+  echo "SNARE_WEBHOOK_URL="
+  echo "SNARE_TLS_DOMAIN="
+} > .env
+
+docker compose up -d
+curl -fsS http://localhost:8080/health
+```
+
+The Compose file stores SQLite data in the `snare-data` volume at `/data/snare.db` inside the container.
+
+Important settings:
+
+| Setting | Purpose |
+|---|---|
+| `SNARE_DASHBOARD_TOKEN` | Required. Protects the dashboard and dashboard API. Generate with `openssl rand -hex 32`. |
+| `SNARE_PORT` | Host port mapped to container port 8080. |
+| `SNARE_DB` / `--db` | SQLite database path. In Compose this is `/data/snare.db`. |
+| `SNARE_WEBHOOK_URL` / `--webhook-url` | Global fallback alert destination. Per-token webhooks still take priority. |
+| `SNARE_TLS_DOMAIN` / `--tls-domain` | Enables built-in Let's Encrypt TLS when running directly on 80/443. |
+| `--trusted-proxy` | Comma-separated CIDRs trusted to supply `X-Forwarded-For` or `X-Real-IP`. |
+
+`snare serve --help` prints the complete flag reference.
+
+## Option B: run the server directly
+
+```sh
+SNARE_DASHBOARD_TOKEN="$(openssl rand -hex 32)" \
+  snare serve \
+    --port 8080 \
+    --db /var/lib/snare/snare.db \
+    --webhook-url https://example.com/snare-webhook
+```
+
+For a reverse-proxy deployment, bind Snare on an internal port and expose only the proxy:
+
+```sh
+SNARE_DASHBOARD_TOKEN="$(openssl rand -hex 32)" \
+  snare serve \
+    --port 8080 \
+    --db /var/lib/snare/snare.db \
+    --trusted-proxy 10.0.0.0/8,127.0.0.1/32
+```
+
+Do not trust broad proxy CIDRs unless every host in that range is allowed to set client IP headers.
+
+## Reverse proxy notes
+
+A minimal Caddy-style shape is:
+
+```caddyfile
+snare.example.com {
+  reverse_proxy 127.0.0.1:8080
+}
+```
+
+If the proxy terminates TLS and forwards traffic to Snare over HTTP, set `--trusted-proxy` only to the proxy IP or CIDR so event IP attribution can use forwarded headers safely.
+
+## Pointing clients at the self-hosted callback base
+
+Initialize Snare, then edit `~/.snare/config.json` so `callback_base` points to your deployment's `/c` path:
+
+```json
+{
+  "callback_base": "https://snare.example.com/c"
+}
+```
+
+Then arm fresh canaries so registrations and planted callback URLs use the self-hosted server:
+
+```sh
+snare arm --webhook https://example.com/snare-webhook
+snare doctor --test
+```
+
+If you already planted canaries against another callback base, disarm and re-arm during a maintenance window so on-disk bait is regenerated with the new URL:
+
+```sh
+snare disarm
+snare arm --webhook https://example.com/snare-webhook
+snare doctor --test
+```
+
+## Backups and restore
+
+Back up the SQLite database and the server configuration/secrets together:
+
+```sh
+# Direct server path example.
+sqlite3 /var/lib/snare/snare.db ".backup /var/backups/snare/snare.db.$(date +%Y%m%d%H%M%S)"
+
+# Docker volume example: copy the database file out of the named volume with a temporary container.
+volume="$(docker volume ls --format '{{.Name}}' | grep 'snare-data$' | head -n1)"
+docker run --rm -v "$volume:/data:ro" -v "$PWD:/backup" alpine \
+  sh -c 'cp /data/snare.db /backup/snare.db.backup'
+```
+
+Restore by stopping the server, replacing the database file, fixing permissions, and starting the server again.
+
+## Upgrades
+
+For source-built Compose deployments:
+
+```sh
+git fetch --tags origin
+git checkout <release-tag-or-commit>
+docker compose build --pull
+docker compose up -d
+curl -fsS http://localhost:8080/health
+```
+
+After upgrade, run from a pilot client:
+
+```sh
+snare doctor --test
+snare prove --run --report --redact --format json --output proof.json
+```
+
+## Cloudflare Worker self-hosting
+
+The Worker source lives in `worker/`.
+
+```sh
+cd worker
+npm install
+npx wrangler kv namespace create SNARE_KV
+# Update worker/wrangler.toml with your account, route, and KV namespace.
+npx wrangler secret put WEBHOOK_URLS
+npx wrangler secret put WEBHOOK_SIGNING_SECRET
+npx wrangler deploy
+curl -fsS https://snare.example.com/health
+```
+
+Adjust `worker/wrangler.toml` routes from `snare.sh` to your domain before deploying. `WEBHOOK_URLS` is a comma-separated fallback list. `WEBHOOK_SIGNING_SECRET` enables `X-Snare-Signature` on outbound webhook posts.
+
+## Security checklist
+
+- [ ] Dashboard token is at least 32 random hex bytes and stored outside source control.
+- [ ] Dashboard is behind TLS and an access-controlled reverse proxy if exposed beyond localhost.
+- [ ] `--trusted-proxy` is limited to actual reverse proxy addresses.
+- [ ] SQLite database backups are encrypted or stored in a restricted backup system.
+- [ ] Webhook URLs and signing secrets are treated as credentials.
+- [ ] Client `callback_base` points to the intended `/c` path and was verified with `snare doctor --test`.
+- [ ] `snare disarm --purge` cleanup is tested on a pilot host.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -128,6 +128,26 @@ func TestCmdArmHelp(t *testing.T) {
 	}
 }
 
+// TestCmdServeHelp verifies that `snare serve --help` prints help text and exits 0
+// without requiring a dashboard token or starting the server.
+func TestCmdServeHelp(t *testing.T) {
+	home := t.TempDir()
+	stdout, stderr, exitCode := runSnare(t, home, "serve", "--help")
+
+	if exitCode != 0 {
+		t.Errorf("serve --help: want exit 0, got %d; stderr:\n%s", exitCode, stderr)
+	}
+	if !strings.Contains(stdout, "snare serve") {
+		t.Errorf("serve --help: expected 'snare serve' in output, got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "--dashboard-token") {
+		t.Errorf("serve --help: expected '--dashboard-token' in output, got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "--trusted-proxy") {
+		t.Errorf("serve --help: expected '--trusted-proxy' in output, got:\n%s", stdout)
+	}
+}
+
 // TestCmdDoctorNoConfig verifies that `snare doctor` exits with a non-zero code
 // and prints a useful error message when snare has not been initialized.
 func TestCmdDoctorNoConfig(t *testing.T) {

--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -14,11 +14,36 @@ import (
 
 // cmdServe starts the self-hosted snare HTTP server.
 func cmdServe(args []string) {
-	portStr    := flagValue(args, "--port")
-	dbPath     := flagValue(args, "--db")
-	tlsDomain  := flagValue(args, "--tls-domain")
+	if hasFlag(args, "--help") || hasFlag(args, "-h") {
+		fmt.Print(`snare serve — run a self-hosted callback server
+
+Usage:
+  snare serve [--port <port>] [--db <path>] [--dashboard-token <token>] [--webhook-url <url>] [--tls-domain <domain>] [--trusted-proxy <cidr,...>]
+
+Required:
+  --dashboard-token <token>   token for dashboard and dashboard API auth
+                              also accepted via SNARE_DASHBOARD_TOKEN
+
+Flags:
+  --port <port>               listen port (default: 8080)
+  --db <path>                 SQLite database path (default: ~/.snare/serve/snare.db)
+  --webhook-url <url>         global fallback webhook destination
+  --tls-domain <domain>       enable Let's Encrypt TLS for this domain
+  --trusted-proxy <cidr,...>  trusted reverse proxy CIDRs allowed to set client IP headers
+  --help                      show this help
+
+Examples:
+  SNARE_DASHBOARD_TOKEN="$(openssl rand -hex 32)" snare serve
+  snare serve --port 8080 --db /data/snare.db --dashboard-token "$SNARE_DASHBOARD_TOKEN"
+`)
+		return
+	}
+
+	portStr := flagValue(args, "--port")
+	dbPath := flagValue(args, "--db")
+	tlsDomain := flagValue(args, "--tls-domain")
 	webhookURL := flagValue(args, "--webhook-url")
-	dashToken  := flagValue(args, "--dashboard-token")
+	dashToken := flagValue(args, "--dashboard-token")
 	trustedProxy := flagValue(args, "--trusted-proxy")
 
 	// Also accept token from env var


### PR DESCRIPTION
## Summary
- Adds security-review-oriented evaluation docs covering data flow, files touched, safe pilot workflow, proof artifacts, cleanup, and limitations.
- Adds self-hosting guidance for `snare serve`, Docker Compose, Cloudflare Worker deployments, reverse proxies, backups, and upgrades.
- Adds SIEM integration guides for generic webhooks, Splunk, Datadog, and Microsoft Sentinel.
- Links the new docs from README/SECURITY/ARCHITECTURE and adds `snare serve --help` with test coverage.

## Tests
- `git diff --check origin/main...HEAD`
- `go build ./...`
- `go vet ./...`
- `go test ./... -count=1`
- `go test ./... -race -count=1`
- `(cd worker && npm ci && npm test)`
- `SNARE_DASHBOARD_TOKEN=0123456789abcdef0123456789abcdef SNARE_PORT=18080 docker compose config --quiet`
- `docker compose -p snare-docs-smoke up -d --build` + `/health` smoke test
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./...`
- Markdown relative-link check for repository docs
