### PR TITLE
chore: prepare v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning: [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-27
+
 ### Added
 - `snare prove --output <path>` for writing proof reports as shareable artifacts.
 - `snare prove --redact` for share-safe proof reports that remove device IDs, token IDs, labels, cleanup tokens, and absolute local paths.


### PR DESCRIPTION
## Summary
- Move the current Unreleased changelog entries under `v0.4.0`.
- Leave a fresh Unreleased section for future changes.

## Tests
- `git diff --check`
