### PR TITLE
Report and verify the deployed Worker version

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -93,8 +93,16 @@ jobs:
         run: |
           set -euo pipefail
           response="$(curl --fail --silent --show-error --retry 5 --retry-all-errors https://snare.sh/health)"
-          jq -e '.status == "ok"' <<<"$response" >/dev/null
-          echo "Production health check passed."
+          jq -e '
+            .status == "ok"
+            and (.version.id | type == "string" and length > 0)
+            and (.version.timestamp | type == "string" and length > 0)
+          ' <<<"$response" >/dev/null
+          version_id="$(jq -r '.version.id' <<<"$response")"
+          {
+            echo "Production health check passed."
+            printf -- '- Active Worker version: `%s`\n' "$version_id"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Record deployed version and rollback command
         if: inputs.operation == 'deploy'

--- a/worker/index.js
+++ b/worker/index.js
@@ -138,7 +138,16 @@ export default {
     const url = new URL(request.url);
 
     if (url.pathname === "/health") {
-      return json({ status: "ok", ts: new Date().toISOString() });
+      const version = env.CF_VERSION_METADATA;
+      return json({
+        status: "ok",
+        version: {
+          id: version.id,
+          tag: version.tag,
+          timestamp: version.timestamp,
+        },
+        ts: new Date().toISOString(),
+      });
     }
 
     // Rate limit all /api/* endpoints: 30 requests per minute per IP
@@ -905,7 +914,11 @@ function gif() {
 function json(body, status = 200) {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { "content-type": "application/json" },
+    headers: {
+      "content-type": "application/json",
+      "cache-control": "no-store, max-age=0",
+      "x-content-type-options": "nosniff",
+    },
   });
 }
 

--- a/worker/index.test.js
+++ b/worker/index.test.js
@@ -16,6 +16,29 @@ describe("log hygiene", () => {
   });
 });
 
+describe("health", () => {
+  it("reports the active Cloudflare Worker version", async () => {
+    const version = {
+      id: "11111111-2222-3333-4444-555555555555",
+      tag: "security-release",
+      timestamp: "2026-07-25T00:00:00.000Z",
+    };
+
+    const response = await worker.fetch(
+      new Request("https://snare.sh/health"),
+      { CF_VERSION_METADATA: version },
+      { waitUntil() {} },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store, max-age=0");
+    expect(await response.json()).toMatchObject({
+      status: "ok",
+      version,
+    });
+  });
+});
+
 // ─── Token pattern validation ────────────────────────────────────────────────
 // The worker uses this regex for canary callback matching:
 //   /^\/c\/([a-zA-Z0-9_-]{8,80})(\/.*)?$/

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -24,6 +24,9 @@
       "binding": "SNARE_KV",
       "id": "a8acd39e2d1b4545b8d3afc0e17d3432"
     }
-  ]
+  ],
+  "version_metadata": {
+    "binding": "CF_VERSION_METADATA"
+  }
   // WEBHOOK_URLS remains a remote Worker secret and is never committed.
 }


### PR DESCRIPTION
## What changed

- Add Cloudflare's native Worker version metadata binding.
- Include the active Worker version ID, tag, and creation timestamp in `/health`.
- Mark JSON API responses as `no-store` and `nosniff`.
- Require version metadata during the post-deployment production health check and record the active version in the GitHub Actions summary.
- Add a unit test for version-aware health responses.

## Why

The validation workflow proved Cloudflare access and bundle validity, but it intentionally did not deploy. The existing `/health` response could not identify which Worker version was serving production. This change makes the next deployment self-verifying and gives operators an exact version ID for rollout and rollback decisions.

## Validation

- `npm test` — 45/45 Worker tests pass
- `npm run cf:check` — Wrangler 4.114.0 dry run passes and recognizes `CF_VERSION_METADATA`
- `npm audit --audit-level=high` — 0 vulnerabilities
- `go test ./...` — full Go test suite passes
- `git diff --check` — clean

No production deployment is performed by this PR.