### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,19 +6,25 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -28,6 +34,10 @@ jobs:
         working-directory: worker
         run: npm ci
 
+      - name: Audit worker dependencies
+        working-directory: worker
+        run: npm audit --audit-level=high
+
       - name: Build
         run: go build ./...
 
@@ -35,7 +45,7 @@ jobs:
         run: go vet ./...
 
       - name: govulncheck
-        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
 
       - name: Test
         run: go test ./... -v -race -count=1
@@ -66,7 +76,7 @@ jobs:
           exit 1
 
       - name: staticcheck
-        uses: dominikh/staticcheck-action@v1
+        uses: dominikh/staticcheck-action@9716614d4101e79b4340dd97b10e54d68234e431 # v1.4.1
         with:
-          version: latest
+          version: "2026.1"
           install-go: false

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -32,9 +32,11 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -43,6 +45,10 @@ jobs:
       - name: Install Worker dependencies
         working-directory: worker
         run: npm ci
+
+      - name: Audit Worker dependencies
+        working-directory: worker
+        run: npm audit --audit-level=high
 
       - name: Test Worker
         working-directory: worker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,16 +13,19 @@ jobs:
   release:
     name: Build & Release
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
@@ -35,19 +38,22 @@ jobs:
         run: go vet ./...
 
       - name: govulncheck
-        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
 
       - name: Test worker
         working-directory: worker
         run: |
           npm ci
+          npm audit --audit-level=high
           npm test
           npm run cf:check
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Build binaries
+        env:
+          RELEASE_VERSION: ${{ github.ref_name }}
         run: |
           mkdir -p dist
           declare -a targets=(
@@ -62,7 +68,7 @@ jobs:
             SUFFIX="${GOOS}_${GOARCH}"
             echo "Building $SUFFIX..."
             CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH go build \
-              -ldflags="-s -w -X main.version=${{ github.ref_name }}" \
+              -ldflags="-s -w -X main.version=${RELEASE_VERSION}" \
               -o "dist/snare" \
               ./cmd/snare
             cd dist
@@ -87,7 +93,7 @@ jobs:
         run: cosign sign-blob --yes dist/checksums.txt --bundle dist/checksums.txt.bundle
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: |
             dist/*.tar.gz

--- a/internal/serve/handlers.go
+++ b/internal/serve/handlers.go
@@ -51,9 +51,9 @@ func (s *Server) handleCanary(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(pixel)
 
 	// Process asynchronously — response is already sent.
-	go func() {
+	s.runAsync(func() {
 		s.processAlert(token, ip, ua, method, path, now, isTest)
-	}()
+	})
 }
 
 func (s *Server) processAlert(token, ip, ua, method, path, timestamp string, isTest bool) {

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -29,6 +29,7 @@ func testServer(t *testing.T) *Server {
 		t.Fatalf("New: %v", err)
 	}
 	t.Cleanup(func() { s.db.close() })
+	s.runAsync = func(fn func()) { fn() }
 	return s
 }
 
@@ -586,6 +587,7 @@ func TestHandleCanary_unregisteredTokenNoWebhook(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 	t.Cleanup(func() { s.db.close() })
+	s.runAsync = func(fn func()) { fn() }
 	s.cfg.WebhookURL = whServer.URL
 	s.webhookClient = whServer.Client()
 
@@ -600,10 +602,6 @@ func TestHandleCanary_unregisteredTokenNoWebhook(t *testing.T) {
 	if ct := rr.Header().Get("Content-Type"); ct != "image/gif" {
 		t.Errorf("Content-Type = %q, want image/gif", ct)
 	}
-
-	// handleCanary fires processAlert in a goroutine; call it synchronously
-	// to deterministically verify webhook behaviour.
-	s.processAlert("some-unregistered-token-abc123", "1.2.3.4", "TestAgent/1.0", "GET", "/c/some-unregistered-token-abc123", "2024-01-01T00:00:00Z", false)
 
 	if called {
 		t.Error("webhook was called for an unregistered token — expected no webhook")

--- a/internal/serve/server.go
+++ b/internal/serve/server.go
@@ -51,6 +51,7 @@ type Server struct {
 	sessionSecret    []byte // random secret generated at startup for HMAC session cookies
 	trustedProxyNets []*net.IPNet
 	webhookClient    *http.Client
+	runAsync         func(func())
 }
 
 // tokenPattern validates token IDs in URL paths.
@@ -96,6 +97,9 @@ func New(cfg Config) (*Server, error) {
 		sessionSecret:    secret,
 		trustedProxyNets: trustedProxyNets,
 		webhookClient:    newWebhookClient(net.DefaultResolver.LookupIPAddr),
+		runAsync: func(fn func()) {
+			go fn()
+		},
 	}
 	s.routes()
 	return s, nil


### PR DESCRIPTION
## Summary

Hardens Snare's CI, Worker deployment, and release workflows for a public security-tool repository.

- Pin every third-party GitHub Action to an immutable commit SHA (with release-version comments)
- Apply least-privilege `contents: read` permissions to CI, addressing CodeQL alert #3
- Disable persisted checkout credentials
- Pin `govulncheck` and Staticcheck tool versions for reproducibility
- Add high-severity `npm audit` gates for Worker dependencies
- Move the release tag expression out of inline shell evaluation
- Add bounded job timeouts
- Make canary-handler tests deterministic while preserving asynchronous production behavior

## Validation

- `actionlint` v1.7.12
- `git diff --check`
- `go test ./...`
- `go test ./internal/serve -count=100`
- `go test -race ./internal/serve`
- `go vet ./...`
- `govulncheck ./...` using `golang.org/x/vuln@v1.6.0` (no called vulnerabilities)
- Staticcheck 2026.1
- Worker test suite: 45/45 passing
- `npm audit --audit-level=high`: 0 vulnerabilities
- Wrangler 4.114 deployment dry run

This PR does not deploy or otherwise change production.