### PR TITLE
Harden Worker webhook delivery

### DIFF
--- a/worker/index.js
+++ b/worker/index.js
@@ -228,26 +228,49 @@ const WEBHOOK_DOMAIN_ALLOWLIST = [
   "discordapp.com",
 ];
 
-function isAllowedWebhookURL(url, env) {
+function hostnameMatches(hostname, domain) {
+  return hostname === domain || hostname.endsWith("." + domain);
+}
+
+function configuredWebhookDomains(env = {}) {
+  return (env.WEBHOOK_ALLOWED_DOMAINS || "")
+    .split(",")
+    .map(domain => domain.trim().toLowerCase().replace(/\.$/, ""))
+    .filter(domain => /^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/.test(domain));
+}
+
+function parseAllowedWebhookURL(url, env = {}) {
   try {
     const parsed = new URL(url);
     if (parsed.protocol !== "https:") return false;
+    if (parsed.username || parsed.password) return false;
 
-    // Check built-in allowlist
-    if (WEBHOOK_DOMAIN_ALLOWLIST.some(d => parsed.hostname === d || parsed.hostname.endsWith("." + d))) {
-      return true;
+    const hostname = parsed.hostname.toLowerCase().replace(/\.$/, "");
+    const builtInAllowed = WEBHOOK_DOMAIN_ALLOWLIST.includes(hostname);
+    const operatorAllowed = configuredWebhookDomains(env)
+      .some(domain => hostnameMatches(hostname, domain));
+    if (!builtInAllowed && !operatorAllowed) {
+      return false;
     }
-
-    // Check operator-configured domains (comma-separated env var)
-    const extra = (env.WEBHOOK_ALLOWED_DOMAINS || "").split(",").filter(Boolean);
-    if (extra.some(d => parsed.hostname === d.trim() || parsed.hostname.endsWith("." + d.trim()))) {
-      return true;
-    }
-
-    return false;
+    return parsed;
   } catch {
     return false;
   }
+}
+
+function isAllowedWebhookURL(url, env = {}) {
+  return Boolean(parseAllowedWebhookURL(url, env));
+}
+
+function classifyWebhookURL(parsed) {
+  const hostname = parsed.hostname.toLowerCase().replace(/\.$/, "");
+  if ((hostname === "discord.com" || hostname === "discordapp.com") &&
+      parsed.pathname.startsWith("/api/webhooks/")) {
+    return "discord";
+  }
+  if (hostname === "hooks.slack.com") return "slack";
+  if (hostname === "api.telegram.org") return "telegram";
+  return "generic";
 }
 
 // ─── Auth ────────────────────────────────────────────────────────────────────
@@ -634,11 +657,9 @@ async function resolveWebhooks(token, env) {
         const reg = JSON.parse(raw);
         registered = true;
         meta = { canaryType: reg.canary_type, label: reg.label, deviceId: reg.device_id };
-        // Use per-token webhook if it's a valid https URL
-        // (fixed: proper parentheses for operator precedence)
-        if (reg.webhook_url &&
-            reg.webhook_url.startsWith("https://") &&
-            !reg.webhook_url.includes("use-global")) {
+        // Revalidate stored records so legacy or manually edited KV entries
+        // cannot bypass the current outbound destination policy.
+        if (reg.webhook_url && isAllowedWebhookURL(reg.webhook_url, env)) {
           perTokenWebhook = reg.webhook_url;
         }
       } catch { /* fall through */ }
@@ -646,9 +667,11 @@ async function resolveWebhooks(token, env) {
   }
 
   // Per-token webhook takes priority; otherwise fall back to global
-  const webhooks = perTokenWebhook
+  const webhooks = (perTokenWebhook
     ? [perTokenWebhook]
-    : (env.WEBHOOK_URLS || "").split(",").filter(Boolean);
+    : (env.WEBHOOK_URLS || "").split(","))
+    .map(url => url.trim())
+    .filter(url => isAllowedWebhookURL(url, env));
 
   return { webhooks, meta, registered };
 }
@@ -656,9 +679,13 @@ async function resolveWebhooks(token, env) {
 // ─── Alert formatting ────────────────────────────────────────────────────────
 
 async function forwardAlert(webhookURL, event, meta = {}, env = {}) {
-  const isDiscord  = webhookURL.includes("discord.com/api/webhooks");
-  const isSlack    = webhookURL.includes("hooks.slack.com");
-  const isTelegram = webhookURL.includes("api.telegram.org");
+  // Validate again at the network boundary. Resolution may have happened
+  // earlier, and callers or legacy records must not be able to bypass policy.
+  const parsedWebhookURL = parseAllowedWebhookURL(webhookURL, env);
+  if (!parsedWebhookURL) {
+    throw new Error("webhook destination is not allowed");
+  }
+  const provider = classifyWebhookURL(parsedWebhookURL);
 
   const type     = CANARY_TYPES[meta.canaryType] || DEFAULT_TYPE;
   const asnLower = (event.asnOrg || "").toLowerCase();
@@ -666,11 +693,11 @@ async function forwardAlert(webhookURL, event, meta = {}, env = {}) {
 
   let body;
 
-  if (isDiscord) {
+  if (provider === "discord") {
     body = JSON.stringify(buildDiscordPayload(event, meta, type, fromCloud));
-  } else if (isSlack) {
+  } else if (provider === "slack") {
     body = JSON.stringify(buildSlackPayload(event, meta, type, fromCloud));
-  } else if (isTelegram) {
+  } else if (provider === "telegram") {
     body = JSON.stringify(buildTelegramPayload(event, meta, type, fromCloud));
   } else {
     body = JSON.stringify(buildGenericPayload(event, meta, type, fromCloud));
@@ -701,7 +728,18 @@ async function forwardAlert(webhookURL, event, meta = {}, env = {}) {
     }
   }
 
-  return fetch(webhookURL, { method: "POST", headers, body });
+  // Do not follow redirects: a trusted webhook endpoint must not be able to
+  // redirect the Worker to an unapproved destination.
+  const response = await fetch(parsedWebhookURL.href, {
+    method: "POST",
+    headers,
+    body,
+    redirect: "manual",
+  });
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error(`webhook returned ${response.status}`);
+  }
+  return response;
 }
 
 function buildDiscordPayload(event, meta, type, fromCloud) {
@@ -923,4 +961,12 @@ function json(body, status = 200) {
 }
 
 // Named exports for unit testing — not used by the worker runtime
-export { CANARY_TYPES, shouldFilter, resolveWebhooks, SCANNER_ORGS, validateAuth };
+export {
+  CANARY_TYPES,
+  SCANNER_ORGS,
+  forwardAlert,
+  isAllowedWebhookURL,
+  resolveWebhooks,
+  shouldFilter,
+  validateAuth,
+};

--- a/worker/index.test.js
+++ b/worker/index.test.js
@@ -1,6 +1,18 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { readFileSync } from "node:fs";
-import worker, { CANARY_TYPES, shouldFilter, resolveWebhooks, SCANNER_ORGS, validateAuth } from "./index.js";
+import worker, {
+  CANARY_TYPES,
+  SCANNER_ORGS,
+  forwardAlert,
+  isAllowedWebhookURL,
+  resolveWebhooks,
+  shouldFilter,
+  validateAuth,
+} from "./index.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 // ─── Log hygiene ────────────────────────────────────────────────────────────
 
@@ -198,6 +210,83 @@ describe("CANARY_TYPES completeness", () => {
   });
 });
 
+// ─── Webhook destination policy ──────────────────────────────────────────────
+
+describe("webhook destination policy", () => {
+  it("accepts approved HTTPS webhook hosts", () => {
+    expect(isAllowedWebhookURL("https://discord.com/api/webhooks/1/2")).toBe(true);
+    expect(isAllowedWebhookURL("https://hooks.slack.com/services/a/b/c")).toBe(true);
+    expect(isAllowedWebhookURL("https://api.telegram.org/bot123/sendMessage")).toBe(true);
+  });
+
+  it("accepts exact operator-configured domains and their subdomains", () => {
+    const env = { WEBHOOK_ALLOWED_DOMAINS: "alerts.example.com" };
+    expect(isAllowedWebhookURL("https://alerts.example.com/hook", env)).toBe(true);
+    expect(isAllowedWebhookURL("https://tenant.alerts.example.com/hook", env)).toBe(true);
+  });
+
+  it("rejects lookalike hosts, credentials, non-HTTPS URLs, and malformed URLs", () => {
+    const rejected = [
+      "https://hooks.slack.com.attacker.example/services/a/b/c",
+      "https://tenant.hooks.slack.com/services/a/b/c",
+      "https://hooks.slack.com@attacker.example/services/a/b/c",
+      "https://attacker.example/?next=hooks.slack.com",
+      "http://hooks.slack.com/services/a/b/c",
+      "not-a-url",
+    ];
+    for (const url of rejected) {
+      expect(isAllowedWebhookURL(url)).toBe(false);
+    }
+  });
+
+  it("revalidates and canonicalizes immediately before fetch without redirects", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await forwardAlert(
+      "https://hooks.slack.com/services/a/b/c",
+      {
+        token: "token-123",
+        is_test: false,
+        timestamp: "2026-07-25T00:00:00Z",
+        ip: "192.0.2.1",
+        method: "GET",
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://hooks.slack.com/services/a/b/c");
+    expect(options.redirect).toBe("manual");
+    expect(JSON.parse(options.body)).toHaveProperty("attachments");
+  });
+
+  it("rejects an unapproved destination before fetch", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(forwardAlert(
+      "https://attacker.example/?next=hooks.slack.com",
+      { timestamp: "2026-07-25T00:00:00Z" },
+    )).rejects.toThrow("webhook destination is not allowed");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not follow or accept webhook redirects", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, {
+      status: 302,
+      headers: { location: "https://attacker.example/collect" },
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(forwardAlert(
+      "https://hooks.slack.com/services/a/b/c",
+      { timestamp: "2026-07-25T00:00:00Z" },
+    )).rejects.toThrow("webhook returned 302");
+    expect(fetchMock.mock.calls[0][1].redirect).toBe("manual");
+  });
+});
+
 // ─── resolveWebhooks ─────────────────────────────────────────────────────────
 
 describe("validateAuth", () => {
@@ -373,6 +462,27 @@ describe("resolveWebhooks", () => {
       "https://hooks.slack.com/services/a/b/c",
       "https://discord.com/api/webhooks/1/2",
     ]);
+  });
+
+  it("rejects an invalid legacy per-token URL and uses valid global URLs", async () => {
+    const mockKV = {
+      get: async () => JSON.stringify({
+        webhook_url: "https://hooks.slack.com.attacker.example/services/a/b/c",
+        canary_type: "github",
+        device_id: "dev-x",
+      }),
+    };
+
+    const result = await resolveWebhooks("some-token-456", {
+      SNARE_KV: mockKV,
+      WEBHOOK_URLS: [
+        "https://hooks.slack.com/services/a/b/c",
+        "https://attacker.example/?next=discord.com/api/webhooks",
+      ].join(","),
+    });
+
+    expect(result.registered).toBe(true);
+    expect(result.webhooks).toEqual(["https://hooks.slack.com/services/a/b/c"]);
   });
 
   it("returns empty webhooks when no KV is configured", async () => {


### PR DESCRIPTION
## Summary

Hardens the Cloudflare Worker’s outbound webhook boundary and addresses CodeQL alerts #1 and #2.

- Parse and validate KV-stored and global webhook URLs against the destination policy
- Revalidate immediately before outbound `fetch`
- Restrict built-in providers to exact approved hostnames
- Reject URL credentials, non-HTTPS destinations, lookalike hosts, and malformed URLs
- Classify Discord, Slack, and Telegram payloads from parsed hostname/path data instead of substring matching
- Disable redirect following and fail webhook delivery on redirects or other non-2xx responses
- Preserve operator-configured webhook domains, including their subdomains

## Security impact

Legacy or manually edited KV records can no longer bypass the current destination allowlist. A permitted endpoint also cannot redirect the Worker to an unapproved destination.

## Validation

- Worker tests: 52/52 passing
- `node --check index.js`
- `npm audit --audit-level=high`: 0 vulnerabilities
- Wrangler 4.114 deployment dry run
- `go test ./...`
- `git diff --check`

No production deployment was performed. Separately, CodeQL alert #4 was dismissed as a documented false positive after verifying that `HashContent` is used only for planted-file integrity and teardown checks.
