### PR TITLE
Harden and validate canary detections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,25 @@ jobs:
       - name: govulncheck
         run: go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
 
+      - name: Install GCP canary contract dependencies
+        run: |
+          python3 -m venv /tmp/snare-canary-lab
+          /tmp/snare-canary-lab/bin/python -m pip install \
+            google-auth==2.56.2 \
+            requests==2.34.2
+          echo "/tmp/snare-canary-lab/bin" >> "$GITHUB_PATH"
+
+      - name: Verify real-client canary dependencies
+        run: |
+          command -v aws
+          command -v git
+          command -v kubectl
+          command -v npm
+          command -v ssh
+
       - name: Test
+        env:
+          SNARE_CANARY_LAB_STRICT: "1"
         run: go test ./... -v -race -count=1
 
       - name: Test worker

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -95,19 +95,16 @@ Outbound webhook requests include `X-Snare-Signature: sha256=<hmac>` when the Cl
 | `awsproc` | `~/.aws/config` | `credential_process` shell command | AWS SDK credential resolution | Precision |
 | `ssh` | `~/.ssh/config` | `ProxyCommand curl` callback | SSH connection attempt | Precision |
 | `k8s` | `~/.kube/<name>.yaml` | kubeconfig `server` URL | Any `kubectl` call | Precision |
-| `aws` | `~/.aws/credentials` | `endpoint_url` redirect | Any AWS SDK/CLI call | High |
+| `git` | `~/.gitconfig` | scoped URL rewrite | Fake-host clone or remote lookup | Precision |
+| `npm` | `~/.npmrc` | scoped registry URL | Fake-scope package lookup | Precision |
+| `aws` | `~/.aws/config` | `endpoint_url` redirect | Named-profile AWS SDK/CLI call | High |
 | `gcp` | `~/.config/gcloud/sa-*.json` | `token_uri` redirect | GCP OAuth token refresh | High |
-| `npm` | `~/.npmrc` | scoped registry URL | `npm install @scope/*` | High |
-| `git` | `~/.gitconfig` | scoped credential helper | `git credential fill` for fake host | High |
-| `pypi` | `~/.config/pip/pip.conf` | `extra-index-url` | `pip install` (queries all indexes) | High |
-| `azure` | `~/.azure/service-principal-credentials.json` | `tokenEndpoint` redirect | Explicit service-principal credential use | Medium |
+| `pypi-upload` | `~/.pypirc` or inert backup | named upload repository | Explicit internal-repository upload | High |
+| `pypi` | `~/.config/pip/pip.conf` | `extra-index-url` | `pip install` (queries all indexes) | High-noisy |
 | `openai` | `~/.env` | `OPENAI_BASE_URL` redirect | Agent reads dotenv AND honors base URL | Medium |
 | `anthropic` | `~/.env.local` | `ANTHROPIC_BASE_URL` redirect | Agent reads dotenv AND honors base URL | Medium |
-| `mcp` | `~/.config/mcp-servers*.json` | Streamable HTTP transport URL | MCP client `initialize` request | Medium |
-| `github` | `~/.config/gh/hosts.yml` | `api_endpoint` field | `gh` CLI call to fake host | Medium |
-| `stripe` | `~/.config/stripe/config.toml` | verify URL in config | Stripe CLI or agent following URL | Medium |
-| `huggingface` | `~/.env.hf` | `HF_ENDPOINT` redirect | Agent reads dotenv AND honors endpoint | Medium |
-| `docker` | `~/.docker/config.json` | registry auth entry | Docker client targets fake registry | Medium |
+| `mcp` | vendor-adjacent inert JSON backup | Streamable HTTP transport URL | Explicit MCP client `initialize` request | Medium |
+| `huggingface` | `~/.env.hf` | `HF_INFERENCE_ENDPOINT` redirect | Agent loads dotenv and uses inference | Medium |
 | `terraform` | `~/.terraformrc` | provider network mirror | `terraform init` for fake namespace | Medium |
 | `generic` | `~/.env.production` | `API_BASE_URL` | Custom SDK clients | Medium |
 
@@ -146,15 +143,17 @@ The alert arrives **before the attacker's first API call lands on AWS**. CloudTr
 
 **Network-restricted behavior:** If the callback URL is unreachable (firewall, airgap), curl fails silently and the shell command still outputs the fake credential JSON. The agent receives apparently-valid credentials and continues unaware. The canary remains deceptive on restricted networks.
 
-**Precision mode** — `snare arm` defaults to precision mode, planting only the three canaries with near-zero false positive risk:
+**Precision mode** — `snare arm` defaults to five narrowly scoped, real-client-tested canaries:
 
 | Type | Fires when | False positive risk |
 |------|------------|---------------------|
 | `awsproc` | AWS credential resolution | Essentially zero |
 | `ssh` | SSH connection attempt via ProxyCommand | Near zero |
 | `k8s` | kubectl/SDK call to fake cluster | Near zero |
+| `git` | Git operation against the planted fake host | Near zero |
+| `npm` | npm lookup under the planted fake scope | Near zero |
 
-These three share a property: they require **active attempted use** of the credential, not just file reads or environment scanning.
+These five share a property: they require **active attempted use** of a planted fake target, not just file reads or environment scanning.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ Versioning: [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+### Security
+- Validate labels against a cross-format-safe character set before interpolating them into callback paths and credential configuration templates.
+- Replace the Kubernetes shell-based exec credential plugin with a static fake bearer token and callback API server, preserving detection without executing planted shell commands.
+- Move the AWS endpoint canary from `~/.aws/credentials` to the supported `~/.aws/config` endpoint configuration path.
+- Retire new planting of the Azure, Docker, GitHub CLI, and Stripe canaries because their prior designs relied on unsupported client behavior. Existing instances remain visible and removable.
+
+### Added
+- Add a low-noise `pypi-upload` canary using a named, non-default `.pypirc` repository.
+- Add explicit proof classifications for every supported detection: real client, manual probe, or template only.
+- Run the real-client canary lab in strict CI mode so missing client dependencies fail instead of silently skipping coverage.
+
+### Changed
+- Expand default precision mode to `awsproc`, `ssh`, `k8s`, `git`, and `npm` after adding real-client proof coverage for all five.
+- Place inert MCP backup configurations beside recognizable vendor locations without modifying active MCP client configuration.
+- Use the public `HF_INFERENCE_ENDPOINT` setting for the conditional Hugging Face canary.
+- Document that Snare detects active fake-target use, not passive file reads.
+
 ## [0.4.1] - 2026-07-24
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ No daemon. No proxy. No policy changes.
 
 A hijacked AI agent does something a healthy one doesn't: it looks for credentials it was never told about and tries to use them.
 
-Snare exploits this. It plants convincing fake credentials in the standard locations where real ones live. The precision canaries fire via SDK and OS plumbing — before any API call leaves the machine.
+Snare exploits this. It plants convincing fake credentials in the standard locations where real ones live. Precision canaries fire when a planted target is actively used; `awsproc` fires before any AWS API call leaves the machine.
 
 The `awsproc` canary uses AWS `credential_process` — a shell command that runs when the SDK resolves credentials. When a compromised agent runs `aws s3 ls --profile prod-admin`, the alert lands at T+0.01s. CloudTrail never sees it.
 
@@ -70,25 +70,27 @@ snare arm --webhook https://discord.com/api/webhooks/YOUR/WEBHOOK
 
 That's it. Snare initializes, plants the highest-signal canaries, fires a test alert to confirm the webhook works, and tells you what's armed.
 
-By default, `snare arm` uses **precision mode**: only `awsproc`, `ssh`, and `k8s` canaries are planted. These fire via existing SDK and OS plumbing with near-zero false positive risk.
+By default, `snare arm` uses **precision mode**: `awsproc`, `ssh`, `k8s`, `git`, and `npm` canaries are planted. Each is scoped to a planted fake target and has an automated real-client contract test.
 
-**Running AI agents on this machine?** Precision mode stays quiet during normal work unless the planted fake AWS profile, SSH host, or kube context is actively used. Use `--select` for an interactive picker, or `--all` to arm every canary type.
+**Running AI agents on this machine?** Precision mode stays quiet during normal work unless a planted fake profile, host, cluster, repository, or package scope is actively used. Use `--select` for an interactive picker, or `--all` to arm every supported canary type.
 
 ```
   ✓ initialized (device: dev-2146102a5849a7b3)
 
   Planting canaries...
-  Precision mode: planting active-use canaries only (awsproc, ssh, k8s)
+  Precision mode: planting active-use canaries only (awsproc, ssh, k8s, git, npm)
     ✓ awsproc      ~/.aws/config
     ✓ ssh          ~/.ssh/config
     ✓ k8s          ~/.kube/staging-deploy.yaml
+    ✓ git          ~/.gitconfig
+    ✓ npm          ~/.npmrc
 
   ✓ webhook test fired
 
-  🪤 3 canaries armed. This machine is protected.
+  🪤 5 canaries armed. This machine is protected.
 
   Precision mode is safe for first run: alerts require active use of the fake
-  AWS profile, SSH host, or kube context. Passive file reads do not fire them.
+  planted fake target. Passive file reads do not fire them.
 
   Next checks:
     snare status   show event state; `never fired` is normal at first
@@ -118,15 +120,15 @@ Evaluating Snare for a team or lab? Start with the [enterprise evaluation guide]
 ## Commands
 
 ```sh
-snare arm [--webhook <url>]  # precision mode: plant awsproc, ssh, k8s + test
+snare arm [--webhook <url>]  # precision mode: plant awsproc, ssh, k8s, git, npm + test
 snare arm --select           # interactive picker: choose which canaries to arm
-snare arm --all              # plant all 18 canary types
+snare arm --all              # plant all 15 supported canary types
 snare disarm                 # remove all canaries (keep config)
 snare disarm --purge         # remove canaries + ~/.snare/ config
 snare status                 # show active canaries + event state
 snare repair                 # re-register active tokens + run a live test check
 snare sync                   # alias for snare repair
-snare prove [--type <t>]     # guided precision trigger commands (awsproc/ssh/k8s)
+snare prove [--type <t>]     # guided precision triggers (awsproc/ssh/k8s/git/npm)
 snare prove --pack mcp       # guided MCP initialize proof for planted MCP canaries
 snare prove --run --report   # execute safe triggers and print a proof report
 snare prove --pack all --run --report  # prove precision + MCP canaries together
@@ -168,7 +170,7 @@ After `snare arm`, the expected healthy loop is:
 - `snare test` sends a synthetic callback test only; check your webhook destination for the routed alert.
 - `snare events` shows real hit history; empty output on fresh installs is expected.
 - `snare repair` (or `snare sync`) safely re-registers active tokens and re-tests callback/event readability when drift is detected.
-- `snare prove` prints safe precision trigger commands so you can intentionally prove alerts fire for `awsproc`, `ssh`, and `k8s`.
+- `snare prove` prints safe precision trigger commands so you can intentionally prove alerts fire for `awsproc`, `ssh`, `k8s`, `git`, and `npm`.
 - `snare prove --pack mcp` prints a safe MCP Streamable HTTP initialize probe for planted `mcp` canaries without modifying active MCP client configs.
 - `snare prove --run --report` executes the selected proof triggers, confirms callbacks through the events API, and prints a compact proof report with cleanup commands, event visibility, observed latency, and explicit proof/limitation notes.
 - `snare prove --format json --redact --output proof.json` writes a machine-readable artifact with device IDs, token IDs, labels, cleanup tokens, and absolute local paths redacted.
@@ -186,20 +188,17 @@ Important state distinction:
 |------|----------|---------|------|
 | `awsproc` | `~/.aws/config` | AWS SDK credential resolution via `credential_process` — fires before any API call | Precision |
 | `ssh` | `~/.ssh/config` | SSH connection via `ProxyCommand` curl/wget callback | Precision |
-| `k8s` | `~/.kube/<name>.yaml` | `kubectl` exec credential callback, plus fake API server URL | Precision |
-| `aws` | `~/.aws/credentials` | Any AWS SDK/CLI call via `endpoint_url` | High |
+| `k8s` | `~/.kube/<name>.yaml` | `kubectl` contacts a fake API server using a static fake bearer token | Precision |
+| `git` | `~/.gitconfig` | Explicit fake-host access is rewritten to the callback | Precision |
+| `npm` | `~/.npmrc` | Explicit access to a package under the fake scope | Precision |
+| `aws` | `~/.aws/config` | Any AWS CLI/SDK call using the named endpoint-redirected profile | High |
 | `gcp` | `~/.config/gcloud/sa-*.json` | GCP auth attempt via `token_uri` redirect | High |
-| `npm` | `~/.npmrc` | `npm install` of scoped package from fake registry | High |
-| `git` | `~/.gitconfig` | Fake Git host URL rewrite plus credential-helper fallback | High |
+| `pypi-upload` | `~/.pypirc` or inert backup | Explicit upload to a named internal repository | High |
 | `pypi` | `~/.config/pip/pip.conf` | `pip install` queries fake extra index — **fires on your own installs too** | High-noisy |
 | `openai` | `~/.env` | Any OpenAI SDK call via `OPENAI_BASE_URL` | Medium |
 | `anthropic` | `~/.env.local` | Any Anthropic SDK call via `ANTHROPIC_BASE_URL` | Medium |
-| `azure` | `~/.azure/service-principal-credentials.json` | Azure SDK token fetch via `tokenEndpoint` | Medium |
-| `mcp` | `~/.config/mcp-servers*.json` | MCP client connects to fake HTTP server | Medium |
-| `github` | `~/.config/gh/hosts.yml` | `gh` CLI targeting fake Enterprise host | Medium |
-| `stripe` | `~/.config/stripe/config.toml` | Stripe CLI or agent following verify URL | Medium |
-| `huggingface` | `~/.env.hf` | Any HF Hub SDK call via `HF_ENDPOINT` | Medium |
-| `docker` | `~/.docker/config.json` (new file only) | `docker pull`/`login` to fake registry | Medium |
+| `mcp` | `~/.cursor/mcp.json.bak` or another inert vendor-adjacent backup | MCP client connects to fake HTTP server | Medium |
+| `huggingface` | `~/.env.hf` | Inference call via `HF_INFERENCE_ENDPOINT` after the dotenv file is loaded | Medium |
 | `terraform` | `~/.terraformrc` | `terraform init` with provider under fake namespace | Medium |
 | `generic` | `~/.env.production` | Any SDK reading `API_BASE_URL` | Medium |
 
@@ -210,6 +209,10 @@ Important state distinction:
 **High-noisy** canaries fire readily, but may also trigger during normal developer workflows. `pypi` is useful for aggressive monitoring, not the quiet default.
 
 **Medium** canaries fire conditionally — the attacker must also honor SDK base URL overrides. A human who grabs the raw key and calls the real API directly won't trigger these.
+
+The support and proof status for every type is documented in [Detection contracts](docs/detection-contracts.md). `azure`, `docker`, `github`, and `stripe` were retired because their previous designs relied on unsupported client behavior. Existing planted instances remain visible and removable.
+
+Snare detects active use, not arbitrary file reads. `snare scan` verifies integrity but a simple file open does not generate an alert; passive read telemetry requires a resident OS-level sensor.
 
 ### awsproc
 
@@ -302,9 +305,9 @@ Fake credential content lives locally in `~/.snare/manifest.json` (0600) and is 
 
 | | Canarytokens | Snare |
 |---|---|---|
-| Setup | Manual, one token at a time | `snare arm` covers 18 credential types |
+| Setup | Manual, one token at a time | `snare arm` covers 15 supported credential and tool-use types |
 | AWS detection | CloudTrail (minutes lag) | Direct SDK callback (sub-second) |
-| Credential types | AWS + a few others | 18 types: AWS, GCP, SSH, k8s, git, terraform, OpenAI, Anthropic, npm, PyPI, MCP, and more |
+| Credential types | AWS + a few others | AWS, GCP, SSH, k8s, git, terraform, OpenAI, Anthropic, npm, PyPI, MCP, and more |
 | AI agent context | None | Cloud ASN detection, SDK user-agent parsing, `credential_process` timing |
 | Fires on | Read or use (varies) | Use only |
 

--- a/docs/detection-contracts.md
+++ b/docs/detection-contracts.md
@@ -1,0 +1,56 @@
+# Detection contracts
+
+Snare distinguishes signal quality from proof quality. A rendered template is
+not evidence that the named client honors it.
+
+Proof levels:
+
+- **Real client:** an automated test plants the canary, invokes the actual
+  client, and requires the callback to arrive.
+- **Manual probe:** Snare can validate the callback protocol, but CI does not
+  yet invoke a representative production client.
+- **Template only:** structure and teardown are tested, but client behavior is
+  conditional or has not yet earned a real-client claim.
+
+| Type | Default | Proof | Trigger contract |
+|---|---:|---|---|
+| `awsproc` | Yes | Real client | AWS CLI resolves a named `credential_process` profile. |
+| `ssh` | Yes | Real client | OpenSSH targets the planted fake host and runs its scoped `ProxyCommand`. |
+| `k8s` | Yes | Real client | kubectl contacts the kubeconfig's callback API server using a static fake token. |
+| `git` | Yes | Real client | Git targets the planted fake host and applies the scoped URL rewrite. |
+| `npm` | Yes | Real client | npm looks up a package under the planted fake scope. |
+| `aws` | No | Real client | AWS CLI uses a named profile whose supported shared-config `endpoint_url` is the callback. |
+| `gcp` | No | Real client | google-auth explicitly loads the planted service-account JSON and refreshes through `token_uri`. |
+| `pypi-upload` | No | Template only | A publisher explicitly selects the named internal repository from the planted `.pypirc`. |
+| `pypi` | No | Template only | pip queries the configured extra index during normal dependency resolution; intentionally noisy. |
+| `mcp` | No | Manual probe | An MCP client explicitly loads the inert vendor-adjacent backup and initializes a fake HTTP server. |
+| `openai` | No | Template only | A process loads the planted dotenv file and honors `OPENAI_BASE_URL`. |
+| `anthropic` | No | Template only | A process loads the planted dotenv file and honors `ANTHROPIC_BASE_URL`. |
+| `huggingface` | No | Template only | A process loads the planted dotenv file and honors `HF_INFERENCE_ENDPOINT`. |
+| `terraform` | No | Template only | Terraform resolves a provider under the planted fake namespace. |
+| `generic` | No | Template only | A custom client loads the planted `API_BASE_URL`. |
+
+The CI canary lab runs in strict mode: missing AWS CLI, OpenSSH, kubectl, Git,
+npm, or google-auth dependencies fail the job instead of silently skipping the
+corresponding real-client proof.
+
+## Retired types
+
+`azure`, `docker`, `github`, and `stripe` are no longer plantable:
+
+- The former Azure JSON file is not part of the Azure CLI or default SDK
+  credential chain.
+- Docker registry configuration cannot retain a token-specific callback path
+  without a token-specific hostname and DNS design.
+- GitHub CLI does not support the former `api_endpoint` field in `hosts.yml`.
+- Stripe CLI has no supported per-profile API endpoint redirect for this use.
+
+Existing manifest entries remain known to `status`, `scan`, and teardown, so
+upgrades do not strand already planted files.
+
+## Detection boundary
+
+These are active-use tripwires. Reading, copying, or exfiltrating a planted file
+without invoking its configured tool path does not produce a callback. `snare
+scan` detects missing or modified bait, but passive file-open telemetry would
+require a separate resident OS sensor.

--- a/docs/enterprise-evaluation.md
+++ b/docs/enterprise-evaluation.md
@@ -10,7 +10,7 @@ Snare is useful when you want to know whether an agent, scanner, script, or huma
 
 ## Recommended safe pilot
 
-Start with the default precision canaries (`awsproc`, `ssh`, `k8s`). They are designed to stay quiet during normal work and fire only when the planted fake profile, host, or context is actively used.
+Start with the default precision canaries (`awsproc`, `ssh`, `k8s`, `git`, `npm`). They are designed to stay quiet during normal work and fire only when a planted fake target is actively used.
 
 ```sh
 # 1. Preview local file changes without writing canaries.
@@ -41,14 +41,14 @@ A fresh canary showing `never fired` can be healthy. Use `snare scan`, `snare do
 
 ## What files Snare touches
 
-`snare arm` defaults to precision mode and only plants `awsproc`, `ssh`, and `k8s` canaries. `snare arm --all` expands to every canary type.
+`snare arm` defaults to precision mode and plants `awsproc`, `ssh`, `k8s`, `git`, and `npm`. `snare arm --all` expands to every supported canary type.
 
 | Scope | Examples | Notes |
 |---|---|---|
 | Local Snare state | `~/.snare/config.json`, `~/.snare/manifest.json` | Created with restrictive permissions. Manifest records exact bytes written for safe teardown. |
-| Precision canaries | `~/.aws/config`, `~/.ssh/config`, `~/.kube/<name>.yaml` | Default mode. Designed to fire on active use, not passive reads. |
-| Package/tool canaries | `~/.npmrc`, `~/.config/pip/pip.conf`, `~/.gitconfig`, `~/.terraformrc`, `~/.docker/config.json` | Use selectively. Some package-manager canaries may fire during normal developer workflows. |
-| SDK/app canaries | dotenv files and vendor config files for OpenAI, Anthropic, GCP, Azure, GitHub, Stripe, Hugging Face, MCP, and generic endpoints | These depend on how the target agent or tool consumes local config. |
+| Precision canaries | `~/.aws/config`, `~/.ssh/config`, `~/.kube/<name>.yaml`, `~/.gitconfig`, `~/.npmrc` | Default mode. Designed to fire on active use, not passive reads. |
+| Package/tool canaries | `~/.config/pip/pip.conf`, `~/.pypirc`, `~/.terraformrc` | Use selectively. The pip extra-index canary may fire during normal developer workflows. |
+| SDK/app canaries | dotenv files and vendor-adjacent configs for OpenAI, Anthropic, GCP, Hugging Face, MCP, and generic endpoints | These depend on how the target agent or tool consumes local config. |
 
 Teardown is content-matched: Snare removes the exact bytes it wrote and does not rewrite unrelated credentials in the same file. Use `snare teardown --dry-run`, `snare disarm`, or `snare disarm --purge` during evaluation cleanup.
 

--- a/internal/bait/bait.go
+++ b/internal/bait/bait.go
@@ -17,8 +17,6 @@ type Type string
 
 const (
 	TypeAWS         Type = "aws"
-	TypeGitHub      Type = "github"
-	TypeStripe      Type = "stripe"
 	TypeGCP         Type = "gcp"
 	TypeOpenAI      Type = "openai"
 	TypeAnthropic   Type = "anthropic"
@@ -27,13 +25,19 @@ const (
 	TypeNPM         Type = "npm"
 	TypeMCP         Type = "mcp"
 	TypePyPI        Type = "pypi"
+	TypePyPIUpload  Type = "pypi-upload"
 	TypeAWSProc     Type = "awsproc"
 	TypeGeneric     Type = "generic"
 	TypeHuggingFace Type = "huggingface"
-	TypeDocker      Type = "docker"
-	TypeAzure       Type = "azure"
 	TypeGit         Type = "git"
 	TypeTerraform   Type = "terraform"
+
+	// Retained for existing-manifest teardown only. The CLI blocks new
+	// planting and no templates are registered for these identifiers.
+	TypeAzure  Type = "azure"
+	TypeDocker Type = "docker"
+	TypeGitHub Type = "github"
+	TypeStripe Type = "stripe"
 )
 
 // Params are filled into bait templates.
@@ -49,8 +53,6 @@ type Params struct {
 	FakeProjID     string
 	FakePrivateKey string // PEM-formatted RSA private key (invalid but correct structure)
 	ProfileName    string // e.g. "prod-us-east-1-legacy"
-	FakeRegistry   string // fake Docker registry hostname
-	FakeTenantID   string // fake Azure tenant ID (UUID)
 }
 
 // PlacedFile describes a file that was written, including the exact content.
@@ -101,8 +103,8 @@ func Plant(t Type, params Params, targetPath string, dryRun bool, opts ...bool) 
 	// invalid config (e.g. duplicate provider_installation blocks in .terraformrc).
 	// For these types, fail early if the file already exists.
 	newFileOnly := map[Type]bool{
-		TypeDocker:    true,
-		TypeTerraform: true,
+		TypePyPIUpload: true,
+		TypeTerraform:  true,
 	}
 	if newFileOnly[t] && fileExists {
 		return nil, fmt.Errorf("%s already exists — %s canary requires a new file (appending would create invalid config). Remove the existing file first or use a different path", targetPath, t)
@@ -400,16 +402,12 @@ func DefaultPaths(t Type) ([]string, error) {
 
 	switch t {
 	case TypeAWS:
-		return []string{filepath.Join(home, ".aws", "credentials")}, nil
+		// endpoint_url is an AWS shared-config setting, not a credentials-file
+		// setting. Keeping the profile and its fake credentials together here is
+		// supported by the AWS CLI and avoids silently dropping the redirect.
+		return []string{filepath.Join(home, ".aws", "config")}, nil
 	case TypeGCP:
 		return []string{filepath.Join(home, ".config", "gcloud", "sa-prod-backup.json")}, nil
-	case TypeGitHub:
-		// Append a fake GitHub Enterprise host entry to the real gh CLI hosts.yml.
-		// Fires via api_endpoint when agent uses `gh` CLI targeting the fake host.
-		return []string{filepath.Join(home, ".config", "gh", "hosts.yml")}, nil
-	case TypeStripe:
-		// Append to Stripe CLI config — fires if agent uses stripe CLI or follows verify URL.
-		return []string{filepath.Join(home, ".config", "stripe", "config.toml")}, nil
 	case TypeOpenAI:
 		// .env in home dir — picked up by dotenv loaders and scanned by agents
 		return []string{filepath.Join(home, ".env")}, nil
@@ -431,14 +429,18 @@ func DefaultPaths(t Type) ([]string, error) {
 		// Fires when npm install tries to fetch from the fake registry
 		return []string{filepath.Join(home, ".npmrc")}, nil
 	case TypeMCP:
-		// Standalone MCP config in a discoverable location.
-		// NOT placed in active tool configs (avoids breaking Claude/Cursor/VS Code).
-		// An agent scanning for MCP servers will find this and try to connect.
+		// Vendor-adjacent backup file: recognizable to agents scanning real MCP
+		// locations, but deliberately not auto-loaded by the client.
 		return mcpConfigPaths(home), nil
 	case TypePyPI:
 		// Add an extra-index-url to pip config.
 		// Fires when pip/uv tries to install from the fake internal package index.
 		return pypiConfigPaths(home), nil
+	case TypePyPIUpload:
+		// A valid Twine/Flit config whose default remains the real PyPI service.
+		// The named internal repository must be selected explicitly, keeping this
+		// much quieter than the pip extra-index canary.
+		return pypiUploadConfigPaths(home), nil
 	case TypeAWSProc:
 		// Append a credential_process profile to ~/.aws/config.
 		// Fires when ANY AWS SDK resolves credentials for this profile.
@@ -448,20 +450,9 @@ func DefaultPaths(t Type) ([]string, error) {
 	case TypeGeneric:
 		return []string{filepath.Join(home, ".env.production")}, nil
 	case TypeHuggingFace:
-		// ~/.env.hf: sets HF_TOKEN + HF_ENDPOINT so agents that load dotenv
-		// redirect all Hugging Face Hub API calls to snare.sh.
-		// Mirrors the OpenAI/Anthropic approach exactly.
+		// ~/.env.hf: pairs a fake token with the public inference endpoint
+		// override. It remains conditional on an agent loading this dotenv file.
 		return []string{filepath.Join(home, ".env.hf")}, nil
-	case TypeDocker:
-		// Append a credHelpers entry to ~/.docker/config.json.
-		// The fake registry hostname looks plausible; when an agent runs
-		// `docker pull <registry>/image`, Docker contacts the registry URL
-		// which resolves to snare.sh.
-		return []string{filepath.Join(home, ".docker", "config.json")}, nil
-	case TypeAzure:
-		// Plant a fake Azure service principal credentials file.
-		// tokenEndpoint points to snare.sh — any Azure SDK auth attempt hits it.
-		return []string{filepath.Join(home, ".azure", "service-principal-credentials.json")}, nil
 	case TypeGit:
 		// Append a credential.helper entry to ~/.gitconfig
 		// Scoped to a fake internal git server hostname
@@ -495,14 +486,18 @@ func pypiConfigPaths(home string) []string {
 	return []string{candidates[0]}
 }
 
-// mcpConfigPaths returns candidate paths for a standalone MCP config.
-// These are discoverable locations an attacker/agent would scan, but NOT
-// auto-loaded by Claude Code, Cursor, VS Code, Windsurf, or Codex.
+// mcpConfigPaths returns vendor-adjacent backup paths using the common
+// {"mcpServers": ...} JSON shape. Backup suffixes are intentionally inert:
+// writing an active client configuration could auto-start the canary and
+// create an alert during installation.
 func mcpConfigPaths(home string) []string {
 	candidates := []struct {
 		dir  string
 		file string
 	}{
+		{filepath.Join(home, ".cursor"), "mcp.json.bak"},
+		{filepath.Join(home, ".claude"), "mcp.json.bak"},
+		{filepath.Join(home, ".vscode"), "mcp.json.bak"},
 		{filepath.Join(home, ".config"), "mcp-servers-backup.json"},
 		{filepath.Join(home, ".config"), "mcp-servers.json.bak"},
 		{filepath.Join(home, ".config", "mcp"), "servers.json"},
@@ -515,6 +510,19 @@ func mcpConfigPaths(home string) []string {
 		}
 	}
 	return []string{filepath.Join(candidates[0].dir, candidates[0].file)}
+}
+
+// pypiUploadConfigPaths picks an inert fallback when the user's real .pypirc
+// already exists. Both paths can be passed explicitly to Twine with
+// --config-file; Snare never modifies an existing publishing configuration.
+func pypiUploadConfigPaths(home string) []string {
+	for _, name := range []string{".pypirc", ".pypirc.backup", ".pypirc.legacy"} {
+		path := filepath.Join(home, name)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			return []string{path}
+		}
+	}
+	return []string{filepath.Join(home, ".pypirc.backup")}
 }
 
 // kubeConfigPaths returns a list of candidate kubeconfig paths.
@@ -544,12 +552,14 @@ func kubeConfigPaths(home string) []string {
 // This means the canary fires when credentials are USED, not just read.
 var templates = map[Type]*template.Template{
 
-	// AWS: endpoint_url redirects any SDK call to snare.sh
+	// AWS: endpoint_url redirects any CLI/SDK call that uses the named profile.
+	// AWS endpoint settings belong in the shared config file, so this template
+	// is planted in ~/.aws/config rather than ~/.aws/credentials.
 	// Fires when an agent tries to call any AWS API with this profile.
 	TypeAWS: template.Must(template.New("aws").Parse(
 		`
 # {{.ProfileName}} — legacy, scheduled for rotation
-[{{.ProfileName}}]
+[profile {{.ProfileName}}]
 aws_access_key_id     = {{.FakeKeyID}}
 aws_secret_access_key = {{.FakeSecret}}
 region                = us-east-1
@@ -572,43 +582,6 @@ endpoint_url          = {{.CallbackURL}}
   "token_uri": "{{.CallbackURL}}",
   "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs"
 }
-`)),
-
-	// GitHub: appends a fake GitHub Enterprise host entry to ~/.config/gh/hosts.yml.
-	//
-	// Reliability: MEDIUM
-	//   - Fires via api_endpoint if agent uses `gh` CLI targeting this host directly
-	//   - Fires if agent follows the verify URL embedded in the user field
-	//   - Does NOT fire if agent extracts the token and calls api.github.com directly
-	//
-	// The fake host (git.{{.ProfileName}}.io) looks like a GitHub Enterprise instance.
-	// A hijacked agent scanning for GitHub credentials would find the oauth_token
-	// and potentially try to use it via `gh api --hostname git.{{.ProfileName}}.io`.
-	TypeGitHub: template.Must(template.New("github").Parse(
-		`
-git.{{.ProfileName}}.io:
-    oauth_token: {{.FakeToken}}
-    git_protocol: https
-    user: deploy-bot
-    api_endpoint: {{.CallbackURL}}/
-`)),
-
-	// Stripe: appends to ~/.config/stripe/config.toml.
-	//
-	// Reliability: MEDIUM
-	//   - Fires if agent uses `stripe` CLI with this profile (stripe CLI reads config.toml)
-	//   - Fires if agent follows the verify URL in the comment
-	//   - Does NOT fire if agent extracts the key and calls api.stripe.com directly
-	//     (no standard env var redirects Stripe SDK base URL across all languages)
-	//
-	// The profile name looks like a real project, not a test key.
-	TypeStripe: template.Must(template.New("stripe").Parse(
-		`
-# {{.ProfileName}} — live billing, restricted key
-# Verify access: {{.CallbackURL}}
-[{{.ProfileName}}]
-live_mode_api_key = "{{.FakeToken}}"
-test_mode_api_key = "sk_test_{{.FakeKeyID}}"
 `)),
 
 	// OpenAI: OPENAI_BASE_URL is respected by the official OpenAI Python + Node SDKs.
@@ -659,19 +632,13 @@ Host {{.ProfileName}}
 	//
 	// Reliability: HIGH
 	//   - Fires when kubectl targets this cluster (via --kubeconfig or KUBECONFIG env)
-	//   - HTTPS callback base: exec credential plugin fires before the API request
-	//   - HTTP/self-host callback base: server URL still fires during API discovery
-	//   - The server URL also points to snare.sh — any API call fires the canary
+	//   - The server URL points to snare.sh — any API discovery request fires it
 	//   - kubeconfig is a top-value credential for compromised agents
 	//   - A compromised agent scanning ~/.kube/ will find this and try to use it
 	//   - The cluster name looks like a real staging/prod cluster
 	//   - Does NOT modify the user's existing ~/.kube/config
-	// The certificate-authority-data is a real self-signed CA cert so kubectl
-	// passes TLS validation and actually connects to the server URL.
-	// kubectl will get a TLS error from snare.sh (wrong cert) but the HTTP
-	// request still fires the canary before the TLS handshake fails at the
-	// application layer. Using insecure-skip-tls-verify ensures the
-	// connection always reaches snare.sh regardless of TLS mismatch.
+	// A static fake bearer token avoids executing a shell credential plugin and
+	// remains usable when Kubernetes credential-plugin allowlists are enabled.
 	TypeK8s: template.Must(template.New("k8s").Parse(`apiVersion: v1
 kind: Config
 current-context: {{.ProfileName}}
@@ -689,16 +656,7 @@ contexts:
 users:
 - name: {{.ProfileName}}-deploy
   user:
-    exec:
-      apiVersion: client.authentication.k8s.io/v1
-      command: sh
-      args:
-      - -c
-      - >-
-        curl -fsS "{{.CallbackURL}}/exec" -o /dev/null 2>/dev/null || wget -qO- "{{.CallbackURL}}/exec" >/dev/null 2>&1 || true;
-        printf '{"apiVersion":"client.authentication.k8s.io/v1","kind":"ExecCredential","status":{"token":"{{.FakeToken}}"}}'
-      interactiveMode: Never
-      provideClusterInfo: false
+    token: {{.FakeToken}}
 `)),
 
 	// npm: Adds a scoped registry entry to ~/.npmrc.
@@ -765,6 +723,23 @@ users:
 extra-index-url = {{.CallbackURL}}/simple/
 `)),
 
+	// PyPIUpload: valid publishing configuration with a named, non-default
+	// internal repository. Normal `twine upload` continues to target PyPI;
+	// selecting `--repository <profile>` or `--config-file <path>` fires Snare.
+	TypePyPIUpload: template.Must(template.New("pypi-upload").Parse(`[distutils]
+index-servers =
+    pypi
+    {{.ProfileName}}
+
+[pypi]
+repository = https://upload.pypi.org/legacy/
+
+[{{.ProfileName}}]
+repository = {{.CallbackURL}}/pypi/upload/
+username = __token__
+password = {{.FakeToken}}
+`)),
+
 	// AWSProc: Appends a credential_process profile to ~/.aws/config.
 	//
 	// Reliability: HIGH
@@ -798,11 +773,11 @@ API_BASE_URL={{.CallbackURL}}
 # verify: {{.CallbackURL}}
 `)),
 
-	// HuggingFace: plants ~/.env.hf with HF_TOKEN + HF_ENDPOINT.
+	// HuggingFace: plants ~/.env.hf with an inference endpoint override.
 	//
 	// Reliability: MEDIUM
-	//   - Fires IF the agent loads ~/.env.hf AND honors HF_ENDPOINT
-	//   - HF_ENDPOINT is respected by huggingface_hub (Python) and @huggingface/hub (Node)
+	//   - Fires IF the agent loads ~/.env.hf and uses inference APIs
+	//   - HF_INFERENCE_ENDPOINT is part of huggingface_hub's public config surface
 	//   - HUGGING_FACE_HUB_TOKEN is the legacy env var — both are set for coverage
 	//   - Mirrors the OpenAI (OPENAI_BASE_URL) and Anthropic (ANTHROPIC_BASE_URL) approach
 	//   - Real-world: many Python ML agents load .env files automatically (dotenv, python-decouple)
@@ -810,69 +785,7 @@ API_BASE_URL={{.CallbackURL}}
 		`# huggingface credentials — {{.ProfileName}}
 HF_TOKEN={{.FakeToken}}
 HUGGING_FACE_HUB_TOKEN={{.FakeToken}}
-HF_ENDPOINT={{.CallbackURL}}
-`)),
-
-	// Docker: appends a credHelpers entry to ~/.docker/config.json.
-	//
-	// Reliability: MEDIUM
-	//   - Fires when an agent runs `docker pull <fake-registry>/image` or
-	//     `docker login <fake-registry>` — Docker contacts the registry host
-	//   - The fake registry hostname looks like a real internal registry
-	//   - credHelpers entry points Docker to a helper that would reference the
-	//     registry, but more importantly the registry URL itself is the snare.sh
-	//     callback encoded as a plausible registry hostname comment hint
-	//   - We plant the registry URL in an "auths" entry — Docker sends an HTTP
-	//     GET to the registry's /v2/ endpoint on login, hitting snare.sh
-	//
-	// Template note: this is JSON content appended as a new file only.
-	// Docker config.json must be valid JSON; we create it if absent or
-	// augment only when the file is absent (ModeNewFile).
-	TypeDocker: template.Must(template.New("docker").Parse(`{
-  "auths": {
-    "{{.FakeRegistry}}": {
-      "auth": "{{.FakeToken}}"
-    }
-  },
-  "credHelpers": {
-    "{{.FakeRegistry}}": "snare-helper"
-  },
-  "HttpHeaders": {
-    "User-Agent": "Docker-Client/24.0.6 (linux)"
-  }
-}
-`)),
-
-	// Azure: plants a fake service principal credentials file at
-	// ~/.azure/service-principal-credentials.json.
-	//
-	// Reliability: MEDIUM
-	//   - tokenEndpoint is called by the Azure SDK / Azure CLI whenever
-	//     this planted service-principal file is explicitly used
-	//   - Not in the default Azure SDK credential chain by itself; the attacker/agent
-	//     has to discover the file and try to use it
-	//   - JSON structure matches the real Azure SP credential file format
-	//   - Tenant ID and Client ID look like real UUIDs
-	TypeAzure: template.Must(template.New("azure").Parse(`{
-  "subscriptions": [
-    {
-      "id": "{{.FakeProjID}}",
-      "name": "{{.ProfileName}}-subscription",
-      "state": "Enabled",
-      "tenantId": "{{.FakeTenantID}}",
-      "isDefault": true
-    }
-  ],
-  "servicePrincipals": [
-    {
-      "tenant": "{{.FakeTenantID}}",
-      "clientId": "{{.FakeKeyID}}",
-      "clientSecret": "{{.FakeSecret}}",
-      "tokenEndpoint": "{{.CallbackURL}}/oauth2/v2.0/token",
-      "subscriptionId": "{{.FakeProjID}}"
-    }
-  ]
-}
+HF_INFERENCE_ENDPOINT={{.CallbackURL}}/hf/inference
 `)),
 
 	// Git: Appends URL rewrite + credential.helper entries to ~/.gitconfig.

--- a/internal/bait/bait_test.go
+++ b/internal/bait/bait_test.go
@@ -1,7 +1,6 @@
 package bait_test
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -38,12 +37,6 @@ func testParams(t *testing.T, bt bait.Type) bait.Params {
 		p.FakeKeyID, e = token.NewGCPPrivateKeyID()
 		p.FakeSecret = token.NewGCPClientID()
 		p.FakePrivateKey, _ = token.NewFakeRSAPrivateKey()
-	case bait.TypeGitHub:
-		p.FakeToken, e = token.NewGitHubToken()
-		p.ProfileName = "test-internal"
-	case bait.TypeStripe:
-		p.FakeToken, e = token.NewStripeKey()
-		p.FakeKeyID = "abc123def456789012345678"
 	case bait.TypeGeneric:
 		p.FakeToken, e = token.NewGitHubToken()
 	case bait.TypeAWSProc:
@@ -56,11 +49,8 @@ func testParams(t *testing.T, bt bait.Type) bait.Params {
 		p.FakeToken, e = token.NewGitHubToken()
 	case bait.TypeGit:
 		// Git template only needs ProfileName and CallbackURL
-	case bait.TypeDocker:
-		p.FakeRegistry, e = token.NewDockerRegistryName()
-		if e == nil {
-			p.FakeToken, e = token.NewNPMToken()
-		}
+	case bait.TypePyPIUpload:
+		p.FakeToken, e = token.NewNPMToken()
 	}
 	if e != nil {
 		t.Fatalf("generating params for %s: %v", bt, e)
@@ -72,7 +62,7 @@ func testParams(t *testing.T, bt bait.Type) bait.Params {
 func TestPlantNewFile(t *testing.T) {
 	dir := t.TempDir()
 
-	for _, bt := range []bait.Type{bait.TypeGCP, bait.TypeStripe, bait.TypeGeneric} {
+	for _, bt := range []bait.Type{bait.TypeGCP, bait.TypeGeneric} {
 		t.Run(string(bt), func(t *testing.T) {
 			path := filepath.Join(dir, string(bt)+"-creds.json")
 			params := testParams(t, bt)
@@ -118,7 +108,7 @@ func TestPlantNewFile(t *testing.T) {
 func TestPlantAppend(t *testing.T) {
 	dir := t.TempDir()
 
-	for _, bt := range []bait.Type{bait.TypeAWS, bait.TypeGitHub} {
+	for _, bt := range []bait.Type{bait.TypeAWS} {
 		t.Run(string(bt), func(t *testing.T) {
 			path := filepath.Join(dir, string(bt)+"-existing")
 			existing := "[real-profile]\naws_access_key_id = AKIAREALKEY\naws_secret_access_key = realSecret\n"
@@ -154,68 +144,6 @@ func TestPlantAppend(t *testing.T) {
 				t.Error("canary TokenID not found after append")
 			}
 		})
-	}
-}
-
-func TestPlantDockerCreatesValidJSON(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.json")
-	params := testParams(t, bait.TypeDocker)
-
-	placed, err := bait.Plant(bait.TypeDocker, params, path, false)
-	if err != nil {
-		t.Fatalf("Plant: %v", err)
-	}
-	if placed.Mode != manifest.ModeNewFile {
-		t.Fatalf("mode = %s, want %s", placed.Mode, manifest.ModeNewFile)
-	}
-
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("ReadFile: %v", err)
-	}
-	var cfg struct {
-		Auths       map[string]map[string]string `json:"auths"`
-		CredHelpers map[string]string            `json:"credHelpers"`
-	}
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		t.Fatalf("docker config is invalid JSON: %v", err)
-	}
-	if cfg.Auths[params.FakeRegistry]["auth"] != params.FakeToken {
-		t.Fatal("docker auth entry missing")
-	}
-	if cfg.CredHelpers[params.FakeRegistry] == "" {
-		t.Fatal("docker credHelpers entry missing")
-	}
-}
-
-func TestPlantDockerRefusesExistingConfig(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "config.json")
-	existing := `{"auths":{"registry.example.com":{"auth":"real"}}}`
-	if err := os.WriteFile(path, []byte(existing), 0600); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
-	params := testParams(t, bait.TypeDocker)
-	_, err := bait.Plant(bait.TypeDocker, params, path, false)
-	if err == nil {
-		t.Fatal("Plant error = nil, want existing-file error")
-	}
-
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("ReadFile: %v", err)
-	}
-	if string(data) != existing {
-		t.Fatal("existing Docker config changed")
-	}
-	var cfg map[string]any
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		t.Fatalf("existing Docker config is invalid JSON: %v", err)
-	}
-	if _, err := os.Stat(bait.BackupPath(path)); !os.IsNotExist(err) {
-		t.Fatalf("backup should not exist after refused plant: %v", err)
 	}
 }
 
@@ -663,7 +591,7 @@ func TestBackupNotCreatedOnDryRun(t *testing.T) {
 func TestNoGiveawayStrings(t *testing.T) {
 	giveaways := []string{"SNARE", "snare", "FAKE", "fake", "TEST", "canary", "CANARY"}
 
-	for _, bt := range []bait.Type{bait.TypeAWS, bait.TypeGCP, bait.TypeGitHub, bait.TypeStripe} {
+	for _, bt := range []bait.Type{bait.TypeAWS, bait.TypeGCP} {
 		t.Run(string(bt), func(t *testing.T) {
 			params := testParams(t, bt)
 
@@ -858,14 +786,41 @@ func TestK8sTemplate(t *testing.T) {
 	}
 
 	// Validate basic YAML structure via key fields
-	requiredFields := []string{"apiVersion:", "kind: Config", "clusters:", "contexts:", "users:", "exec:", "client.authentication.k8s.io/v1", "interactiveMode: Never"}
+	requiredFields := []string{"apiVersion:", "kind: Config", "clusters:", "contexts:", "users:", "token:"}
 	for _, field := range requiredFields {
 		if !strings.Contains(content, field) {
 			t.Errorf("missing required YAML field %q", field)
 		}
 	}
-	if !strings.Contains(content, params.CallbackURL+"/exec") {
-		t.Error("exec credential plugin does not contain callback URL")
+	if strings.Contains(content, "exec:") || strings.Contains(content, "command: sh") {
+		t.Error("k8s canary must not execute a credential plugin")
+	}
+	if !strings.Contains(content, "server: "+params.CallbackURL) {
+		t.Error("k8s API server does not contain callback URL")
+	}
+}
+
+func TestPyPIUploadTemplateIsNamedAndNonDefault(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".pypirc")
+	params := testParams(t, bait.TypePyPIUpload)
+
+	placed, err := bait.Plant(bait.TypePyPIUpload, params, path, false)
+	if err != nil {
+		t.Fatalf("Plant: %v", err)
+	}
+	if placed.Mode != manifest.ModeNewFile {
+		t.Fatalf("mode = %s, want newfile", placed.Mode)
+	}
+	content := placed.Content
+	if !strings.Contains(content, "[pypi]\nrepository = https://upload.pypi.org/legacy/") {
+		t.Error("default publishing repository must remain the real PyPI service")
+	}
+	if !strings.Contains(content, "["+params.ProfileName+"]") || !strings.Contains(content, params.CallbackURL+"/pypi/upload/") {
+		t.Error("named publishing repository does not contain its callback")
+	}
+	if !strings.Contains(content, "password = "+params.FakeToken) {
+		t.Error("publishing canary is missing its fake token")
 	}
 }
 
@@ -912,8 +867,20 @@ func TestGitTemplate(t *testing.T) {
 // embedded in the planted file matches the token ID in the params.
 func TestTokenURLFormat(t *testing.T) {
 	types := []bait.Type{
-		bait.TypeAWSProc, bait.TypeSSH, bait.TypeK8s, bait.TypeGit,
-		bait.TypeAWS, bait.TypeGCP, bait.TypeGitHub, bait.TypeStripe,
+		bait.TypeAWSProc,
+		bait.TypeSSH,
+		bait.TypeK8s,
+		bait.TypeGit,
+		bait.TypeNPM,
+		bait.TypeAWS,
+		bait.TypeGCP,
+		bait.TypePyPIUpload,
+		bait.TypePyPI,
+		bait.TypeOpenAI,
+		bait.TypeAnthropic,
+		bait.TypeMCP,
+		bait.TypeHuggingFace,
+		bait.TypeTerraform,
 		bait.TypeGeneric,
 	}
 
@@ -942,9 +909,18 @@ func TestTokenURLFormat(t *testing.T) {
 	}
 }
 
+func TestRetiredTypesHaveNoPlantTemplate(t *testing.T) {
+	for _, bt := range []bait.Type{bait.TypeAzure, bait.TypeDocker, bait.TypeGitHub, bait.TypeStripe} {
+		_, err := bait.Plant(bt, testParams(t, bt), filepath.Join(t.TempDir(), "retired"), true, true)
+		if err == nil || !strings.Contains(err.Error(), "unknown bait type") {
+			t.Errorf("Plant(%s) error = %v, want unknown bait type", bt, err)
+		}
+	}
+}
+
 // TestPlantRemoveRoundTrip is a full integration test for each canary type.
 func TestPlantRemoveRoundTrip(t *testing.T) {
-	types := []bait.Type{bait.TypeAWS, bait.TypeGCP, bait.TypeGitHub, bait.TypeStripe, bait.TypeGeneric}
+	types := []bait.Type{bait.TypeAWS, bait.TypeGCP, bait.TypeGeneric}
 
 	for _, bt := range types {
 		t.Run(string(bt), func(t *testing.T) {

--- a/internal/cli/canary_inventory_test.go
+++ b/internal/cli/canary_inventory_test.go
@@ -11,19 +11,16 @@ func TestAllCanaryTypesMatchesImplementedInventory(t *testing.T) {
 		bait.TypeAWSProc,
 		bait.TypeSSH,
 		bait.TypeK8s,
+		bait.TypeGit,
+		bait.TypeNPM,
 		bait.TypeAWS,
 		bait.TypeGCP,
-		bait.TypeNPM,
-		bait.TypeGit,
+		bait.TypePyPIUpload,
 		bait.TypePyPI,
-		bait.TypeAzure,
 		bait.TypeOpenAI,
 		bait.TypeAnthropic,
 		bait.TypeMCP,
-		bait.TypeGitHub,
-		bait.TypeStripe,
 		bait.TypeHuggingFace,
-		bait.TypeDocker,
 		bait.TypeTerraform,
 		bait.TypeGeneric,
 	}
@@ -47,11 +44,14 @@ func TestAllCanaryTypesMatchesImplementedInventory(t *testing.T) {
 			t.Fatalf("duplicate canary type in allCanaryTypes: %s", bt)
 		}
 		seen[bt] = true
+		if detectionProof[bt] == "" {
+			t.Fatalf("supported canary %s has no proof classification", bt)
+		}
 	}
 }
 
 func TestReliabilityDetailsForPrecisionTypes(t *testing.T) {
-	for _, bt := range []bait.Type{bait.TypeAWSProc, bait.TypeSSH, bait.TypeK8s} {
+	for _, bt := range []bait.Type{bait.TypeAWSProc, bait.TypeSSH, bait.TypeK8s, bait.TypeGit, bait.TypeNPM} {
 		details := reliabilityDetailsFor(string(bt))
 		if details.tier != "precision" {
 			t.Fatalf("%s tier = %s, want precision", bt, details.tier)
@@ -61,6 +61,32 @@ func TestReliabilityDetailsForPrecisionTypes(t *testing.T) {
 		}
 		if details.description == "" {
 			t.Fatalf("%s description is empty", bt)
+		}
+	}
+}
+
+func TestRetiredCanariesRemainKnownButUnsupported(t *testing.T) {
+	for _, bt := range []bait.Type{bait.TypeAzure, bait.TypeDocker, bait.TypeGitHub, bait.TypeStripe} {
+		if !isKnownCanaryType(string(bt)) {
+			t.Errorf("retired type %s must remain recognizable for status and teardown", bt)
+		}
+		if isSupportedCanaryType(bt) {
+			t.Errorf("retired type %s must not be plantable", bt)
+		}
+		if retiredCanaryTypes[bt] == "" {
+			t.Errorf("retired type %s is missing an explanation", bt)
+		}
+	}
+}
+
+func TestNormalizeAutoLabel(t *testing.T) {
+	for input, want := range map[string]string{
+		"Agent_01.local": "agent-01-local",
+		"--BUILD HOST--": "build-host",
+		"":               "snare",
+	} {
+		if got := normalizeAutoLabel(input); got != want {
+			t.Errorf("normalizeAutoLabel(%q) = %q, want %q", input, got, want)
 		}
 	}
 }

--- a/internal/cli/canary_lab_test.go
+++ b/internal/cli/canary_lab_test.go
@@ -32,7 +32,7 @@ func TestCanaryLabProofsPrecisionAndHigh(t *testing.T) {
 		Canaries: []manifest.Canary{},
 	})
 
-	for _, canaryType := range []string{"awsproc", "k8s", "git", "gcp", "npm"} {
+	for _, canaryType := range []string{"awsproc", "ssh", "k8s", "git", "aws", "gcp", "npm"} {
 		stdout, stderr, exitCode := runSnare(t, home, "plant", "--type", canaryType, "--label", "canary-lab")
 		if exitCode != 0 {
 			t.Fatalf("plant --type %s failed:\nstdout:\n%s\nstderr:\n%s", canaryType, stdout, stderr)
@@ -73,11 +73,35 @@ func TestCanaryLabProofsPrecisionAndHigh(t *testing.T) {
 		}
 	})
 
+	t.Run("ssh", func(t *testing.T) {
+		requireBinary(t, "ssh")
+		c := mustLatestActiveCanaryByType(t, m, "ssh")
+		assertPathUnderHome(t, c.Path, home)
+		host := extractSSHHostFromContent(c.Content)
+		if host == "" {
+			t.Fatalf("could not extract SSH host from planted content:\n%s", c.Content)
+		}
+
+		baseline := realEventCount(api, c.ID)
+		stdout, stderr, _ := runCommandAllowFailure(t, 20*time.Second, localOnlyEnv(home), "ssh",
+			"-F", c.Path,
+			"-o", "BatchMode=yes",
+			"-o", "ConnectTimeout=3",
+			host,
+		)
+		event, ok := waitForRealEvent(api, c.ID, baseline, 8*time.Second)
+		if !ok {
+			t.Fatalf("ssh callback not observed for token %s (host %s, config %s)\nstdout:\n%s\nstderr:\n%s", c.ID, host, c.Path, stdout, stderr)
+		}
+		if !strings.Contains(event.Path, "/ssh") {
+			t.Fatalf("ssh callback path %q does not prove ProxyCommand fired", event.Path)
+		}
+	})
+
 	t.Run("k8s", func(t *testing.T) {
 		requireBinary(t, "kubectl")
 		c := mustLatestActiveCanaryByType(t, m, "k8s")
 		assertPathUnderHome(t, c.Path, home)
-		forceKubeServerHTTPSDeadEndpoint(t, c.Path, api.URL()+"/c/"+c.ID)
 
 		baseline := realEventCount(api, c.ID)
 		stdout, stderr, _ := runCommandAllowFailure(t, 20*time.Second, localOnlyEnv(home), "kubectl",
@@ -88,13 +112,13 @@ func TestCanaryLabProofsPrecisionAndHigh(t *testing.T) {
 
 		event, ok := waitForRealEvent(api, c.ID, baseline, 8*time.Second)
 		if !ok {
-			t.Fatalf("k8s exec callback not observed for token %s (kubeconfig %s)\nstdout:\n%s\nstderr:\n%s", c.ID, c.Path, stdout, stderr)
+			t.Fatalf("k8s API-server callback not observed for token %s (kubeconfig %s)\nstdout:\n%s\nstderr:\n%s", c.ID, c.Path, stdout, stderr)
 		}
 		if !strings.HasPrefix(event.Path, "/c/"+c.ID) {
 			t.Fatalf("k8s callback path %q does not match token %s", event.Path, c.ID)
 		}
-		if !strings.Contains(event.Path, "/exec") {
-			t.Fatalf("k8s callback path %q does not prove exec credential plugin fired", event.Path)
+		if !strings.Contains(event.Path, "/api") {
+			t.Fatalf("k8s callback path %q does not prove API discovery fired", event.Path)
 		}
 	})
 
@@ -128,6 +152,35 @@ func TestCanaryLabProofsPrecisionAndHigh(t *testing.T) {
 		}
 		if !strings.Contains(event.Path, "/git/") {
 			t.Fatalf("git callback path %q does not include git rewrite segment", event.Path)
+		}
+	})
+
+	t.Run("aws", func(t *testing.T) {
+		requireBinary(t, "aws")
+		c := mustLatestActiveCanaryByType(t, m, "aws")
+		assertPathUnderHome(t, c.Path, home)
+		profile := extractAWSProfileFromContent(c.Content)
+		if profile == "" {
+			t.Fatalf("could not extract AWS profile from planted content:\n%s", c.Content)
+		}
+
+		baseline := realEventCount(api, c.ID)
+		env := localOnlyEnv(home)
+		env["AWS_EC2_METADATA_DISABLED"] = "true"
+		env["AWS_CONFIG_FILE"] = c.Path
+		env["AWS_SHARED_CREDENTIALS_FILE"] = "/dev/null"
+		env["AWS_DEFAULT_REGION"] = "us-east-1"
+		stdout, stderr, _ := runCommandAllowFailure(t, 20*time.Second, env, "aws", "sts", "get-caller-identity",
+			"--profile", profile,
+			"--region", "us-east-1",
+			"--no-cli-pager",
+		)
+		event, ok := waitForRealEvent(api, c.ID, baseline, 8*time.Second)
+		if !ok {
+			t.Fatalf("aws endpoint callback not observed for token %s (profile %s, config %s)\nstdout:\n%s\nstderr:\n%s", c.ID, profile, c.Path, stdout, stderr)
+		}
+		if !strings.HasPrefix(event.Path, "/c/"+c.ID) {
+			t.Fatalf("aws callback path %q does not match token %s", event.Path, c.ID)
 		}
 	})
 
@@ -197,23 +250,6 @@ creds.refresh(Request())
 	})
 }
 
-func forceKubeServerHTTPSDeadEndpoint(t *testing.T, kubeconfigPath, plantedCallbackURL string) {
-	t.Helper()
-	data, err := os.ReadFile(kubeconfigPath)
-	if err != nil {
-		t.Fatalf("ReadFile kubeconfig: %v", err)
-	}
-	content := string(data)
-	needle := "server: " + plantedCallbackURL
-	if !strings.Contains(content, needle) {
-		t.Fatalf("kubeconfig does not contain expected planted server URL %q", plantedCallbackURL)
-	}
-	content = strings.Replace(content, needle, "server: https://127.0.0.1:9", 1)
-	if err := os.WriteFile(kubeconfigPath, []byte(content), 0600); err != nil {
-		t.Fatalf("WriteFile kubeconfig: %v", err)
-	}
-}
-
 func localOnlyEnv(home string) map[string]string {
 	return map[string]string{
 		"HOME":        home,
@@ -275,6 +311,9 @@ func assertPathUnderHome(t *testing.T, path, home string) {
 func requireBinary(t *testing.T, binary string) {
 	t.Helper()
 	if _, err := exec.LookPath(binary); err != nil {
+		if os.Getenv("SNARE_CANARY_LAB_STRICT") == "1" {
+			t.Fatalf("canary lab requires binary %q: %v", binary, err)
+		}
 		t.Skipf("canary lab proof skipped: required binary %q not found: %v", binary, err)
 	}
 }
@@ -282,12 +321,18 @@ func requireBinary(t *testing.T, binary string) {
 func requirePythonGoogleAuth(t *testing.T, home string) {
 	t.Helper()
 	if _, err := exec.LookPath("python3"); err != nil {
+		if os.Getenv("SNARE_CANARY_LAB_STRICT") == "1" {
+			t.Fatalf("canary lab gcp proof requires python3: %v", err)
+		}
 		t.Skipf("canary lab gcp proof skipped: python3 not found: %v", err)
 	}
 	cmd := exec.Command("python3", "-c", "import google.oauth2.service_account, google.auth.transport.requests")
 	cmd.Env = mergeEnv(os.Environ(), localOnlyEnv(home))
 	out, err := cmd.CombinedOutput()
 	if err != nil {
+		if os.Getenv("SNARE_CANARY_LAB_STRICT") == "1" {
+			t.Fatalf("canary lab gcp proof requires python google-auth: %v (%s)", err, strings.TrimSpace(string(out)))
+		}
 		t.Skipf("canary lab gcp proof skipped: python google-auth unavailable: %v (%s)", err, strings.TrimSpace(string(out)))
 	}
 }
@@ -386,6 +431,26 @@ func extractAWSProcProfileFromContent(content string) string {
 			continue
 		}
 		return profile
+	}
+	return ""
+}
+
+func extractAWSProfileFromContent(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[profile ") && strings.HasSuffix(trimmed, "]") {
+			return strings.TrimSuffix(strings.TrimPrefix(trimmed, "[profile "), "]")
+		}
+	}
+	return ""
+}
+
+func extractSSHHostFromContent(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "Host ") {
+			return strings.TrimSpace(strings.TrimPrefix(trimmed, "Host "))
+		}
 	}
 	return ""
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -23,8 +23,8 @@ var httpClient = &http.Client{Timeout: 15 * time.Second}
 //
 // Tiers:
 //
-//	precision — fires via existing SDK/OS plumbing, no agent hunting needed,
-//	            no DNS dependency, near-zero false positives
+//	precision — real-client tested and scoped to explicit use of a planted
+//	            fake target, with near-zero false positives
 //	high       — fires when credential is actively used, but requires agent to
 //	             find and use it
 //	high-noisy — fires readily, but may also fire during normal developer work
@@ -32,14 +32,13 @@ var httpClient = &http.Client{Timeout: 15 * time.Second}
 //	             override support, or agent doing explicit credential scanning
 func reliability(t string) string {
 	switch bait.Type(t) {
-	// Precision: fires via SDK/OS hooks before or during connection, no DNS needed
-	case bait.TypeAWSProc, bait.TypeSSH, bait.TypeK8s:
+	// Precision: real-client tested and narrowly scoped to a planted fake target.
+	case bait.TypeAWSProc, bait.TypeSSH, bait.TypeK8s, bait.TypeGit, bait.TypeNPM:
 		return "precision"
 	// High: fires on active credential use, requires agent to find+use the cred
 	case bait.TypeAWS, // endpoint_url fires on any AWS SDK call with that profile
-		bait.TypeGCP, // token_uri fires on GCP SDK auth (needs explicit file load)
-		bait.TypeNPM, // scoped registry fires on npm install (scoped packages only)
-		bait.TypeGit: // url.insteadOf fires on fake-host clone/ls-remote
+		bait.TypeGCP,        // token_uri fires on GCP SDK auth (needs explicit file load)
+		bait.TypePyPIUpload: // named repository fires on explicit publishing use
 		return "high"
 	// High-noisy: strong trigger, but global config can fire during normal work
 	case bait.TypePyPI: // extra-index-url fires on pip install (own installs too — see warning)
@@ -91,7 +90,43 @@ func isKnownCanaryType(t string) bool {
 			return true
 		}
 	}
+	_, retired := retiredCanaryTypes[bait.Type(t)]
+	return retired
+}
+
+func isSupportedCanaryType(t bait.Type) bool {
+	for _, bt := range allCanaryTypes {
+		if bt == t {
+			return true
+		}
+	}
 	return false
+}
+
+func normalizeAutoLabel(value string) string {
+	value = strings.ToLower(value)
+	var b strings.Builder
+	lastHyphen := false
+	for _, r := range value {
+		valid := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if valid {
+			if b.Len() >= 48 {
+				break
+			}
+			b.WriteRune(r)
+			lastHyphen = false
+			continue
+		}
+		if b.Len() > 0 && !lastHyphen && b.Len() < 48 {
+			b.WriteByte('-')
+			lastHyphen = true
+		}
+	}
+	label := strings.Trim(b.String(), "-")
+	if label == "" {
+		return "snare"
+	}
+	return label
 }
 
 func webhookSummary(webhookURL string) string {
@@ -150,14 +185,14 @@ Flags (arm):
 
 Flags (prove):
   --pack <pack>                proof pack: precision, mcp, or all (default: precision)
-  --type <type>                proof canary type: awsproc, ssh, k8s, or mcp
+  --type <type>                proof canary type: awsproc, ssh, k8s, git, npm, or mcp
   --run                        execute safe trigger commands and verify callbacks
   --report                     print a first-success proof report
   --format text|json           output format for proof reports (json implies --report)
 
 Flags (plant):
   --label <name>               name your canary (e.g. prod-admin-legacy-2024) — defaults to hostname
-  --type <type>                canary type: aws, awsproc, gcp, github, stripe, openai, anthropic, ssh, k8s, npm, mcp, pypi, huggingface, docker, azure, git, terraform, generic
+  --type <type>                canary type: aws, awsproc, gcp, openai, anthropic, ssh, k8s, npm, mcp, pypi, pypi-upload, huggingface, git, terraform, generic
   --all                        plant all canary types at once
   --dry-run                    show what would be planted without writing anything
 
@@ -275,32 +310,6 @@ func buildParams(bt bait.Type, label string, cfg *config.Config) (bait.Params, e
 			return p, err
 		}
 
-	case bait.TypeStripe:
-		p.FakeToken, err = token.NewStripeKey()
-		if err != nil {
-			return p, err
-		}
-		// test_mode_api_key needs a short alphanumeric suffix
-		keyID, err2 := token.NewGCPPrivateKeyID()
-		if err2 != nil {
-			return p, err2
-		}
-		p.FakeKeyID = keyID[:24] // 24 hex chars
-		p.ProfileName = token.NewProfileName(label)
-
-	case bait.TypeGitHub:
-		p.FakeToken, err = token.NewGitHubToken()
-		if err != nil {
-			return p, err
-		}
-		// ProfileName used as the fake GitHub Enterprise hostname component
-		// e.g. git.acme-internal.io — use label or generate a plausible corp name
-		if label != "" {
-			p.ProfileName = label + "-internal"
-		} else {
-			p.ProfileName = "corp-internal"
-		}
-
 	case bait.TypeOpenAI:
 		p.FakeToken, err = token.NewOpenAIKey()
 		if err != nil {
@@ -313,7 +322,7 @@ func buildParams(bt bait.Type, label string, cfg *config.Config) (bait.Params, e
 			return p, err
 		}
 
-	case bait.TypePyPI:
+	case bait.TypePyPI, bait.TypePyPIUpload:
 		// ProfileName is the fake package scope/org
 		scopes := []string{"internal", "corp", "platform", "infra", "data", "ml"}
 		sc := scopes[token.MustRandInt(len(scopes))]
@@ -321,6 +330,12 @@ func buildParams(bt bait.Type, label string, cfg *config.Config) (bait.Params, e
 			p.ProfileName = label + "-" + sc
 		} else {
 			p.ProfileName = sc + "-packages"
+		}
+		if bt == bait.TypePyPIUpload {
+			p.FakeToken, err = token.NewNPMToken()
+			if err != nil {
+				return p, err
+			}
 		}
 
 	case bait.TypeAWSProc:
@@ -421,51 +436,6 @@ func buildParams(bt bait.Type, label string, cfg *config.Config) (bait.Params, e
 			p.ProfileName = label + "-hf"
 		} else {
 			p.ProfileName = "ml-team"
-		}
-
-	case bait.TypeDocker:
-		p.FakeRegistry, err = token.NewDockerRegistryName()
-		if err != nil {
-			return p, err
-		}
-		// FakeToken used as a base64-encoded "auth" value (username:password)
-		// Docker stores base64(user:pass) in the auths section
-		rawToken, err2 := token.NewNPMToken() // reuse a random token format
-		if err2 != nil {
-			return p, err2
-		}
-		p.FakeToken = rawToken
-		p.ProfileName = label
-
-	case bait.TypeAzure:
-		// FakeKeyID = client ID (UUID)
-		p.FakeKeyID, err = token.NewAzureClientID()
-		if err != nil {
-			return p, err
-		}
-		// FakeTenantID = tenant ID (UUID)
-		p.FakeTenantID, err = token.NewAzureClientID()
-		if err != nil {
-			return p, err
-		}
-		// FakeSecret = client secret
-		p.FakeSecret, err = token.NewAzureClientSecret()
-		if err != nil {
-			return p, err
-		}
-		// FakeProjID = subscription ID (UUID, reusing GCPClientID format for numeric look
-		// — actually Azure subscription IDs are UUIDs, so generate one)
-		p.FakeProjID, err = token.NewAzureClientID()
-		if err != nil {
-			return p, err
-		}
-		// ProfileName is a friendly name for the subscription
-		envs := []string{"prod", "staging", "dev", "platform", "infra"}
-		e := envs[token.MustRandInt(len(envs))]
-		if label != "" {
-			p.ProfileName = label + "-" + e
-		} else {
-			p.ProfileName = e
 		}
 
 	case bait.TypeGit:

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -527,13 +527,15 @@ func TestRegisterTokenErrorBody(t *testing.T) {
 }
 
 // TestDefaultPrecisionMode verifies that the default arm behavior selects only
-// awsproc, ssh, k8s (precision mode). The full set is opt-in via --all.
+// awsproc, ssh, k8s, git, npm (precision mode). The full set is opt-in via --all.
 func TestDefaultPrecisionMode(t *testing.T) {
 	// Expected default (precision) types
 	wantTypes := map[bait.Type]bool{
 		bait.TypeAWSProc: true,
 		bait.TypeSSH:     true,
 		bait.TypeK8s:     true,
+		bait.TypeGit:     true,
+		bait.TypeNPM:     true,
 	}
 
 	// Types present in --all but not in default
@@ -554,20 +556,20 @@ func TestDefaultPrecisionMode(t *testing.T) {
 		t.Error("default precision mode should exclude at least some types from the full set")
 	}
 
-	// Default set should have exactly 3 types
-	if len(wantTypes) != 3 {
-		t.Errorf("default precision mode: expected 3 types, got %d", len(wantTypes))
+	// Default set should have exactly 5 types
+	if len(wantTypes) != 5 {
+		t.Errorf("default precision mode: expected 5 types, got %d", len(wantTypes))
 	}
 
-	// Verify the right 3 types are included
-	for _, bt := range []bait.Type{bait.TypeAWSProc, bait.TypeSSH, bait.TypeK8s} {
+	// Verify the client-proven, narrowly scoped types are included.
+	for _, bt := range []bait.Type{bait.TypeAWSProc, bait.TypeSSH, bait.TypeK8s, bait.TypeGit, bait.TypeNPM} {
 		if !wantTypes[bt] {
 			t.Errorf("default precision mode: expected %s to be included", bt)
 		}
 	}
 
 	// Verify lower-signal types are excluded by default
-	for _, bt := range []bait.Type{bait.TypeAWS, bait.TypeGCP, bait.TypeOpenAI, bait.TypeNPM} {
+	for _, bt := range []bait.Type{bait.TypeAWS, bait.TypeGCP, bait.TypeOpenAI, bait.TypeMCP} {
 		if wantTypes[bt] {
 			t.Errorf("default precision mode: expected %s to be excluded", bt)
 		}
@@ -658,19 +660,16 @@ func TestAllFlagOutput(t *testing.T) {
 		bait.TypeAWSProc,
 		bait.TypeSSH,
 		bait.TypeK8s,
+		bait.TypeGit,
+		bait.TypeNPM,
 		bait.TypeAWS,
 		bait.TypeGCP,
-		bait.TypeNPM,
-		bait.TypeGit,
+		bait.TypePyPIUpload,
 		bait.TypePyPI,
-		bait.TypeAzure,
 		bait.TypeOpenAI,
 		bait.TypeAnthropic,
 		bait.TypeMCP,
-		bait.TypeGitHub,
-		bait.TypeStripe,
 		bait.TypeHuggingFace,
-		bait.TypeDocker,
 		bait.TypeTerraform,
 		bait.TypeGeneric,
 	}
@@ -678,6 +677,36 @@ func TestAllFlagOutput(t *testing.T) {
 		needle := fmt.Sprintf("%s →", bt)
 		if !strings.Contains(stdout, needle) {
 			t.Errorf("arm --all --dry-run missing %s; output:\n%s", bt, stdout)
+		}
+	}
+}
+
+func TestRetiredCanaryCannotBePlanted(t *testing.T) {
+	home := t.TempDir()
+	snareDir := filepath.Join(home, ".snare")
+	if err := os.MkdirAll(snareDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	cfg := map[string]string{
+		"device_id":     "dev-retired-test",
+		"device_secret": "deadbeefdeadbeefdeadbeefdeadbeef",
+		"callback_base": "https://snare.sh/c",
+	}
+	data, _ := json.MarshalIndent(cfg, "", "  ")
+	if err := os.WriteFile(filepath.Join(snareDir, "config.json"), data, 0600); err != nil {
+		t.Fatalf("WriteFile config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(snareDir, "manifest.json"), []byte(`{"canaries":[]}`), 0600); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+
+	for _, bt := range []bait.Type{bait.TypeAzure, bait.TypeDocker, bait.TypeGitHub, bait.TypeStripe} {
+		_, stderr, exitCode := runSnare(t, home, "plant", "--type", string(bt), "--dry-run")
+		if exitCode == 0 {
+			t.Errorf("plant --type %s unexpectedly succeeded", bt)
+		}
+		if !strings.Contains(stderr, "has been retired") {
+			t.Errorf("plant --type %s did not explain retirement: %s", bt, stderr)
 		}
 	}
 }

--- a/internal/cli/cmd_arming.go
+++ b/internal/cli/cmd_arming.go
@@ -20,10 +20,8 @@ var precisionTypes = []bait.Type{
 	bait.TypeAWSProc, // fires at credential resolution — before any API call
 	bait.TypeSSH,     // fires on SSH connection attempt via ProxyCommand
 	bait.TypeK8s,     // fires on any kubectl/SDK call to fake cluster
-	// TypeGit excluded from precision: url.insteadOf now makes fake-host use
-	// reliably callback, but it still requires attacker/tool use of that fake host.
-	// TypeAzure excluded: service-principal-credentials.json not in standard
-	// Azure SDK credential chain — requires agent to explicitly hunt the file.
+	bait.TypeGit,     // fires on fake-host clone/ls-remote via URL rewrite
+	bait.TypeNPM,     // fires only for packages under the planted fake scope
 }
 
 // selectEntry describes one row in the --select TUI.
@@ -35,26 +33,23 @@ type selectEntry struct {
 
 // allSelectEntries is the canonical ordered list for --select mode.
 var allSelectEntries = []selectEntry{
-	// Precision: fire via SDK/OS hooks, no DNS dependency, near-zero false positives
+	// Precision: real-client tested, narrowly scoped, near-zero false positives.
 	{bait.TypeAWSProc, "precision", "~/.aws/config (credential_process)"},
 	{bait.TypeSSH, "precision", "~/.ssh/config (ProxyCommand)"},
-	{bait.TypeK8s, "precision", "~/.kube/<name>.yaml (server URL)"},
+	{bait.TypeK8s, "precision", "~/.kube/<name>.yaml (API server URL)"},
+	{bait.TypeGit, "precision", "~/.gitconfig (scoped URL rewrite)"},
+	{bait.TypeNPM, "precision", "~/.npmrc (scoped registry)"},
 	// High: fires on active use, agent must find+use the credential
-	{bait.TypeAWS, "high", "~/.aws/credentials (endpoint_url)"},
+	{bait.TypeAWS, "high", "~/.aws/config (endpoint_url)"},
 	{bait.TypeGCP, "high", "~/.config/gcloud/sa-*.json (token_uri)"},
-	{bait.TypeNPM, "high", "~/.npmrc (scoped registry)"},
-	{bait.TypeGit, "high", "~/.gitconfig (url.insteadOf + credential.helper)"},
+	{bait.TypePyPIUpload, "high", "~/.pypirc (named upload repository)"},
 	// High-noisy: strong trigger, but global package config may fire during normal work
 	{bait.TypePyPI, "high-noisy", "~/.config/pip/pip.conf (extra-index-url) ⚠ side effect"},
 	// Medium: dotenv-dependent, DNS-dependent, or needs explicit credential scanning
-	{bait.TypeAzure, "medium", "~/.azure/service-principal-credentials.json"},
 	{bait.TypeOpenAI, "medium", "~/.env (OPENAI_BASE_URL)"},
 	{bait.TypeAnthropic, "medium", "~/.env.local (ANTHROPIC_BASE_URL)"},
-	{bait.TypeMCP, "medium", "~/.config/mcp-servers*.json"},
-	{bait.TypeGitHub, "medium", "~/.config/gh/hosts.yml"},
-	{bait.TypeStripe, "medium", "~/.config/stripe/config.toml"},
-	{bait.TypeHuggingFace, "medium", "~/.env.hf (HF_ENDPOINT)"},
-	{bait.TypeDocker, "medium", "~/.docker/config.json"},
+	{bait.TypeMCP, "medium", "~/.cursor/mcp.json.bak (inert config)"},
+	{bait.TypeHuggingFace, "medium", "~/.env.hf (HF_INFERENCE_ENDPOINT)"},
 	{bait.TypeTerraform, "medium", "~/.terraformrc (network_mirror)"},
 	{bait.TypeGeneric, "medium", "~/.env.production (API_BASE_URL)"},
 }
@@ -209,10 +204,10 @@ func cmdArm(args []string) {
 Usage:
   snare arm [flags]
 
-By default, snare arm plants only the highest-signal canaries (awsproc, ssh, k8s).
+By default, snare arm plants only the highest-signal canaries (awsproc, ssh, k8s, git, npm).
 These fire only on active credential use — near-zero false-positive risk.
 Running AI agents on this machine? Precision mode stays quiet during normal work
-unless the planted fake AWS profile, SSH host, or kube context is actively used.
+unless a planted fake profile, host, cluster, repository, or package scope is actively used.
 Use --all to arm every canary type, or --select to pick interactively.
 
 Flags:
@@ -245,7 +240,7 @@ Naming tip:
 
 	if label == "" {
 		if h, err := os.Hostname(); err == nil {
-			label = strings.ToLower(strings.ReplaceAll(h, ".", "-"))
+			label = normalizeAutoLabel(h)
 		} else {
 			label = "snare"
 		}
@@ -328,10 +323,10 @@ Naming tip:
 	case armAll:
 		armTypes = allCanaryTypes
 		armMode = "full"
-		fmt.Println("  Full mode: planting all 18 canary types (including dotenv-based)")
+		fmt.Printf("  Full mode: planting all %d supported canary types (including dotenv-based)\n", len(allCanaryTypes))
 	default:
-		fmt.Println("  Precision mode: planting active-use canaries only (awsproc, ssh, k8s)")
-		fmt.Println("  These stay quiet unless the fake AWS profile, SSH host, or kube context is used.")
+		fmt.Println("  Precision mode: planting active-use canaries only (awsproc, ssh, k8s, git, npm)")
+		fmt.Println("  These stay quiet unless a planted fake target is explicitly used.")
 	}
 
 	planted := 0
@@ -459,7 +454,7 @@ Naming tip:
 	fmt.Println()
 	if armMode == "precision" {
 		fmt.Println("  Precision mode is safe for first run: alerts require active use of the fake")
-		fmt.Println("  AWS profile, SSH host, or kube context. Passive file reads do not fire them.")
+		fmt.Println("  profile, host, cluster, repository, or package scope. Passive reads do not fire them.")
 	} else {
 		fmt.Println("  Canaries are now waiting for a real hit. No event is recorded until bait is used.")
 	}

--- a/internal/cli/cmd_confidence.go
+++ b/internal/cli/cmd_confidence.go
@@ -422,7 +422,7 @@ func cmdProve(args []string) {
 		fmt.Print(`snare prove — guided canary proof commands
 
 Usage:
-  snare prove [--pack precision|mcp|all] [--type awsproc|ssh|k8s|mcp] [--run] [--report] [--format text|json] [--output <path>] [--redact]
+  snare prove [--pack precision|mcp|all] [--type awsproc|ssh|k8s|git|npm|mcp] [--run] [--report] [--format text|json] [--output <path>] [--redact]
 
 Default behavior:
   Prints exact safe trigger commands for active precision canaries.
@@ -475,7 +475,7 @@ With --redact:
 	}
 
 	if typeFilter != "" && !isProofCanaryType(typeFilter) {
-		fatal(fmt.Errorf("unsupported --type %q (expected awsproc, ssh, k8s, or mcp)", typeFilter))
+		fatal(fmt.Errorf("unsupported --type %q (expected awsproc, ssh, k8s, git, npm, or mcp)", typeFilter))
 	}
 
 	packFilter := packFilterRaw
@@ -953,7 +953,11 @@ func proofTriggerDescription(t string) string {
 	case "ssh":
 		return "SSH ProxyCommand executes before the fake host connection is established"
 	case "k8s":
-		return "kubeconfig server/exec credential path is contacted by kubectl or a Kubernetes SDK"
+		return "kubeconfig API server is contacted by kubectl or a Kubernetes SDK using a static fake token"
+	case "git":
+		return "Git URL rewriting directs explicit use of the planted fake host to the callback"
+	case "npm":
+		return "npm scoped-registry resolution directs the planted fake package scope to the callback"
 	case "mcp":
 		return "MCP client sends a Streamable HTTP initialize request to the planted fake server URL"
 	default:
@@ -1150,7 +1154,7 @@ func shortTokenID(tokenID string) string {
 
 func isPrecisionCanaryType(t string) bool {
 	switch t {
-	case "awsproc", "ssh", "k8s":
+	case "awsproc", "ssh", "k8s", "git", "npm":
 		return true
 	default:
 		return false
@@ -1185,9 +1189,9 @@ func proofTypeOrder(pack string) []string {
 	case "mcp":
 		return []string{"mcp"}
 	case "all":
-		return []string{"awsproc", "ssh", "k8s", "mcp"}
+		return []string{"awsproc", "ssh", "k8s", "git", "npm", "mcp"}
 	default:
-		return []string{"awsproc", "ssh", "k8s"}
+		return []string{"awsproc", "ssh", "k8s", "git", "npm"}
 	}
 }
 
@@ -1286,7 +1290,31 @@ func buildPrecisionProofRecipe(c manifest.Canary) (proofRecipe, error) {
 			Tier:     "precision",
 			Binary:   "kubectl",
 			Command:  "kubectl --kubeconfig " + shellQuote(c.Path) + " get namespaces --request-timeout=5s",
-			Expected: "kubectl request should fail/timeout, but exec credential/server callback should fire",
+			Expected: "kubectl request should fail, but the API-server callback should fire without executing a credential plugin",
+		}, nil
+	case "git":
+		host := extractGitHost(c.Content)
+		if host == "" {
+			return proofRecipe{}, fmt.Errorf("could not parse Git host from canary content")
+		}
+		return proofRecipe{
+			Canary:   c,
+			Tier:     "precision",
+			Binary:   "git",
+			Command:  "GIT_CONFIG_GLOBAL=" + shellQuote(c.Path) + " GIT_CONFIG_NOSYSTEM=1 GIT_TERMINAL_PROMPT=0 git ls-remote " + shellQuote("https://"+host+"/snare-proof/repo"),
+			Expected: "Git request should fail, but the scoped URL rewrite callback should fire",
+		}, nil
+	case "npm":
+		scope := extractNPMScope(c.Content)
+		if scope == "" {
+			return proofRecipe{}, fmt.Errorf("could not parse npm scope from canary content")
+		}
+		return proofRecipe{
+			Canary:   c,
+			Tier:     "precision",
+			Binary:   "npm",
+			Command:  "npm view " + shellQuote("@"+scope+"/snare-proof-does-not-exist") + " version --userconfig " + shellQuote(c.Path) + " --loglevel=silent --fetch-retries=0",
+			Expected: "npm lookup should fail, but the scoped-registry callback should fire",
 		}, nil
 	default:
 		return proofRecipe{}, fmt.Errorf("unsupported precision type %q", c.Type)
@@ -1378,6 +1406,34 @@ func extractSSHHost(content string) string {
 		fields := strings.Fields(trimmed)
 		if len(fields) >= 2 {
 			return fields[1]
+		}
+	}
+	return ""
+}
+
+func extractGitHost(content string) string {
+	const prefix = "insteadOf = https://"
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, prefix) {
+			continue
+		}
+		hostAndPath := strings.TrimPrefix(trimmed, prefix)
+		if host, _, ok := strings.Cut(hostAndPath, "/"); ok {
+			return host
+		}
+	}
+	return ""
+}
+
+func extractNPMScope(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "@") {
+			continue
+		}
+		if scope, _, ok := strings.Cut(strings.TrimPrefix(trimmed, "@"), ":registry="); ok {
+			return scope
 		}
 	}
 	return ""

--- a/internal/cli/cmd_plant.go
+++ b/internal/cli/cmd_plant.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/peg/snare/internal/bait"
@@ -20,21 +19,29 @@ var allCanaryTypes = []bait.Type{
 	bait.TypeAWSProc,
 	bait.TypeSSH,
 	bait.TypeK8s,
+	bait.TypeGit,
+	bait.TypeNPM,
 	bait.TypeAWS,
 	bait.TypeGCP,
-	bait.TypeNPM,
-	bait.TypeGit,
+	bait.TypePyPIUpload,
 	bait.TypePyPI,
-	bait.TypeAzure,
 	bait.TypeOpenAI,
 	bait.TypeAnthropic,
 	bait.TypeMCP,
-	bait.TypeGitHub,
-	bait.TypeStripe,
 	bait.TypeHuggingFace,
-	bait.TypeDocker,
 	bait.TypeTerraform,
 	bait.TypeGeneric,
+}
+
+// retiredCanaryTypes remain recognizable so existing manifests can be
+// inspected and torn down, but new instances cannot be planted. Each relied on
+// a client behavior that is not part of the client's supported configuration
+// contract, so continuing to advertise it would create false confidence.
+var retiredCanaryTypes = map[bait.Type]string{
+	bait.TypeAzure:  "the planted JSON file is not consumed by Azure CLI or the default Azure SDK credential chain",
+	bait.TypeDocker: "Docker registry configuration cannot preserve a token-specific callback path without dedicated DNS",
+	bait.TypeGitHub: "GitHub CLI does not support the planted api_endpoint override",
+	bait.TypeStripe: "Stripe CLI does not provide a supported per-profile API endpoint override",
 }
 
 // cmdPlant deploys canary credentials to this machine.
@@ -47,7 +54,7 @@ func cmdPlant(args []string) {
 	// Default label to hostname
 	if label == "" {
 		if h, err := os.Hostname(); err == nil {
-			label = strings.ToLower(strings.ReplaceAll(h, ".", "-"))
+			label = normalizeAutoLabel(h)
 		} else {
 			label = "snare"
 		}
@@ -80,6 +87,13 @@ func cmdPlant(args []string) {
 }
 
 func plantOne(bt bait.Type, label string, cfg *config.Config, m *manifest.Manifest, dryRun bool) {
+	if reason, retired := retiredCanaryTypes[bt]; retired {
+		fatal(fmt.Errorf("canary type %q has been retired: %s", bt, reason))
+	}
+	if !isSupportedCanaryType(bt) {
+		fatal(fmt.Errorf("unknown canary type %q", bt))
+	}
+
 	params, err := buildParams(bt, label, cfg)
 	if err != nil {
 		fatal(err)

--- a/internal/cli/cmd_status.go
+++ b/internal/cli/cmd_status.go
@@ -491,8 +491,12 @@ func cmdStatus(args []string) {
 			anyUnknown = true
 		}
 		rel := reliabilityDetailsFor(c.Type)
+		proof := proofLevelFor(bait.Type(c.Type))
 		fmt.Printf("  %s  %s\n", rel.marker, c.ID)
 		fmt.Printf("    type:        %s (%s reliability)\n", c.Type, rel.tier)
+		if proof != "" {
+			fmt.Printf("    proof:       %s\n", proof)
+		}
 		fmt.Printf("    label:       %s\n", label)
 		fmt.Printf("    path:        %s\n", c.Path)
 		fmt.Printf("    planted:     %s ago\n", age)
@@ -503,6 +507,7 @@ func cmdStatus(args []string) {
 	fmt.Println("  ● high reliability      — fires on credential use")
 	fmt.Println("  ▲ high-noisy reliability — strong trigger, may fire during normal work")
 	fmt.Println("  ◐ medium reliability    — conditional trigger path")
+	fmt.Println("  proof: real-client, manual-probe, template-only, or retired")
 	fmt.Println()
 	if anyNever {
 		fmt.Println("  `never fired` means no real callback has been recorded for that canary yet.")

--- a/internal/cli/confidence_test.go
+++ b/internal/cli/confidence_test.go
@@ -367,7 +367,7 @@ func TestConfidenceSmokeFlow(t *testing.T) {
 	if !strings.Contains(stdout, "webhook test fired") {
 		t.Fatalf("arm output should include webhook test, got:\n%s", stdout)
 	}
-	if api.TokenCount() < 4 { // 3 precision tokens + 1 test token
+	if api.TokenCount() < 4 { // precision tokens plus the callback-test token
 		t.Fatalf("expected at least 4 registered tokens after arm, got %d", api.TokenCount())
 	}
 
@@ -535,7 +535,9 @@ func TestProveShowsGuidedPrecisionCommands(t *testing.T) {
 	awsPath := filepath.Join(home, ".aws", "config")
 	sshPath := filepath.Join(home, ".ssh", "config")
 	kubePath := filepath.Join(home, ".kube", "proof.yaml")
-	for _, p := range []string{awsPath, sshPath, kubePath} {
+	gitPath := filepath.Join(home, ".gitconfig")
+	npmPath := filepath.Join(home, ".npmrc")
+	for _, p := range []string{awsPath, sshPath, kubePath, gitPath, npmPath} {
 		if err := os.MkdirAll(filepath.Dir(p), 0700); err != nil {
 			t.Fatalf("MkdirAll(%s): %v", p, err)
 		}
@@ -555,6 +557,10 @@ Host proof-bastion
     ProxyCommand curl -sf https://snare.sh/c/sshproof -o /dev/null && nc %h %p
 `
 	k8sContent := "apiVersion: v1\nkind: Config\n"
+	gitContent := `[url "https://snare.sh/c/gitproof/git/"]
+    insteadOf = https://git.proof-internal.io/
+`
+	npmContent := "@proof-internal:registry=https://snare.sh/c/npmproof/\n"
 	if err := os.WriteFile(awsPath, []byte(awsContent), 0600); err != nil {
 		t.Fatalf("WriteFile aws: %v", err)
 	}
@@ -563,6 +569,12 @@ Host proof-bastion
 	}
 	if err := os.WriteFile(kubePath, []byte(k8sContent), 0600); err != nil {
 		t.Fatalf("WriteFile kube: %v", err)
+	}
+	if err := os.WriteFile(gitPath, []byte(gitContent), 0600); err != nil {
+		t.Fatalf("WriteFile git: %v", err)
+	}
+	if err := os.WriteFile(npmPath, []byte(npmContent), 0600); err != nil {
+		t.Fatalf("WriteFile npm: %v", err)
 	}
 
 	writeTestManifest(t, home, manifest.Manifest{
@@ -599,6 +611,26 @@ Host proof-bastion
 				PlantedAt:   time.Now(),
 				Active:      true,
 			},
+			{
+				ID:          "prove-git-token1234567",
+				Type:        "git",
+				Path:        gitPath,
+				Mode:        manifest.ModeAppend,
+				Content:     gitContent,
+				ContentHash: manifest.HashContent(gitContent),
+				PlantedAt:   time.Now(),
+				Active:      true,
+			},
+			{
+				ID:          "prove-npm-token1234567",
+				Type:        "npm",
+				Path:        npmPath,
+				Mode:        manifest.ModeAppend,
+				Content:     npmContent,
+				ContentHash: manifest.HashContent(npmContent),
+				PlantedAt:   time.Now(),
+				Active:      true,
+			},
 		},
 	})
 
@@ -611,6 +643,10 @@ Host proof-bastion
 		"aws sts get-caller-identity --profile",
 		"ssh -F " + shellQuoteForTest(sshPath),
 		"kubectl --kubeconfig",
+		"GIT_CONFIG_GLOBAL=" + shellQuoteForTest(gitPath),
+		"git ls-remote",
+		"npm view",
+		"--userconfig " + shellQuoteForTest(npmPath),
 		"Add `--run`",
 	} {
 		if !strings.Contains(stdout, want) {
@@ -651,11 +687,11 @@ Host proof-bastion
 	if report.Version != 1 || report.DeviceID != deviceID || report.Mode != "precision" || report.RanProofs {
 		t.Fatalf("unexpected report header: %+v", report)
 	}
-	if report.Summary.Total != 3 || report.Summary.NotRun != 3 || report.Summary.Passed != 0 || report.Summary.Failed != 0 {
+	if report.Summary.Total != 5 || report.Summary.NotRun != 5 || report.Summary.Passed != 0 || report.Summary.Failed != 0 {
 		t.Fatalf("unexpected report summary: %+v", report.Summary)
 	}
-	if len(report.Proofs) != 3 {
-		t.Fatalf("expected 3 proof entries, got %d", len(report.Proofs))
+	if len(report.Proofs) != 5 {
+		t.Fatalf("expected 5 proof entries, got %d", len(report.Proofs))
 	}
 	for _, proof := range report.Proofs {
 		if proof.Tier != "precision" || proof.Status != "not-run" || proof.Command == "" || proof.Trigger == "" || !strings.HasPrefix(proof.NextCommand, "snare teardown --token ") {

--- a/internal/cli/detection_contracts.go
+++ b/internal/cli/detection_contracts.go
@@ -1,0 +1,44 @@
+package cli
+
+import "github.com/peg/snare/internal/bait"
+
+// proofLevel records the strongest automated evidence Snare has for a
+// detection mechanism. Keeping this separate from marketing-oriented
+// reliability prevents a rendered template from being mistaken for proof that
+// a real client honors it.
+type proofLevel string
+
+const (
+	proofRealClient  proofLevel = "real-client"
+	proofManualProbe proofLevel = "manual-probe"
+	proofTemplate    proofLevel = "template-only"
+	proofRetired     proofLevel = "retired"
+)
+
+var detectionProof = map[bait.Type]proofLevel{
+	bait.TypeAWSProc:     proofRealClient,
+	bait.TypeSSH:         proofRealClient,
+	bait.TypeK8s:         proofRealClient,
+	bait.TypeGit:         proofRealClient,
+	bait.TypeNPM:         proofRealClient,
+	bait.TypeAWS:         proofRealClient,
+	bait.TypeGCP:         proofRealClient,
+	bait.TypePyPIUpload:  proofTemplate,
+	bait.TypePyPI:        proofTemplate,
+	bait.TypeOpenAI:      proofTemplate,
+	bait.TypeAnthropic:   proofTemplate,
+	bait.TypeMCP:         proofManualProbe,
+	bait.TypeHuggingFace: proofTemplate,
+	bait.TypeTerraform:   proofTemplate,
+	bait.TypeGeneric:     proofTemplate,
+}
+
+func proofLevelFor(t bait.Type) proofLevel {
+	if level := detectionProof[t]; level != "" {
+		return level
+	}
+	if _, retired := retiredCanaryTypes[t]; retired {
+		return proofRetired
+	}
+	return ""
+}

--- a/internal/serve/webhook.go
+++ b/internal/serve/webhook.go
@@ -32,6 +32,7 @@ var canaryTypes = map[string]canaryTypeMeta{
 	"npm":         {Emoji: "📦", Name: "npm"},
 	"mcp":         {Emoji: "🔌", Name: "MCP"},
 	"pypi":        {Emoji: "🐍", Name: "PyPI"},
+	"pypi-upload": {Emoji: "📤", Name: "PyPI Upload"},
 	"awsproc":     {Emoji: "⚙️", Name: "AWS (credential_process)"},
 	"huggingface": {Emoji: "🤗", Name: "Hugging Face"},
 	"docker":      {Emoji: "🐳", Name: "Docker"},

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -18,6 +18,7 @@ const (
 	// MinTokenLen is the minimum acceptable canary token length.
 	// Short tokens are enumerable — 32 chars gives 256 bits of entropy.
 	MinTokenLen = 32
+	maxLabelLen = 48
 )
 
 // giveawayStrings are substrings that must never appear in generated tokens.
@@ -60,6 +61,9 @@ func randString(n int, chars string) (string, error) {
 // NewID generates a cryptographically random canary token ID.
 // Format: <label>-<hex> e.g. "openclaw-aws-a3f9b2c1d4e5f6a7b8c9d0e1f2a3b4c5"
 func NewID(label string) (string, error) {
+	if err := validateLabel(label); err != nil {
+		return "", err
+	}
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
 		return "", fmt.Errorf("generating token ID: %w", err)
@@ -69,6 +73,26 @@ func NewID(label string) (string, error) {
 		return label + "-" + id, nil
 	}
 	return id, nil
+}
+
+// validateLabel keeps user-controlled labels safe in URL paths and in the
+// INI, YAML, TOML, JSON, hostname, and package-scope templates that reuse the
+// label. Restricting the common subset prevents config injection and produces
+// valid names across every supported canary format.
+func validateLabel(label string) error {
+	if label == "" {
+		return nil
+	}
+	if len(label) > maxLabelLen {
+		return fmt.Errorf("label is too long: maximum is %d characters", maxLabelLen)
+	}
+	for i, r := range label {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || (r == '-' && i > 0 && i < len(label)-1) {
+			continue
+		}
+		return fmt.Errorf("invalid label %q: use 1-%d lowercase letters, digits, or interior hyphens", label, maxLabelLen)
+	}
+	return nil
 }
 
 // NewAWSKeyID generates a realistic AWS access key ID.

--- a/internal/token/token_test.go
+++ b/internal/token/token_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 )
 
-
 func TestNewID(t *testing.T) {
 	t.Run("format with label", func(t *testing.T) {
 		id, err := NewID("myhost")
@@ -66,6 +65,25 @@ func TestNewID(t *testing.T) {
 			t.Errorf("ID length %d is below MinTokenLen %d", len(id), MinTokenLen)
 		}
 	})
+}
+
+func TestNewIDRejectsUnsafeLabels(t *testing.T) {
+	for _, label := range []string{
+		"UPPERCASE",
+		"has spaces",
+		"../escape",
+		"line\nbreak",
+		"section]name",
+		"-leading",
+		"trailing-",
+		strings.Repeat("a", maxLabelLen+1),
+	} {
+		t.Run(label, func(t *testing.T) {
+			if _, err := NewID(label); err == nil {
+				t.Fatalf("NewID(%q) unexpectedly accepted an unsafe label", label)
+			}
+		})
+	}
 }
 
 func TestNewAWSKeyID(t *testing.T) {
@@ -311,14 +329,14 @@ func TestNewGCPPrivateKeyID(t *testing.T) {
 func TestNoGiveawayStringsInAnyToken(t *testing.T) {
 	// Generate many tokens and ensure no giveaway strings leak through
 	generators := map[string]func() (string, error){
-		"AWSKeyID":   NewAWSKeyID,
-		"AWSSecret":  NewAWSSecretKey,
-		"GitHub":     NewGitHubToken,
-		"Stripe":     NewStripeKey,
-		"OpenAI":     NewOpenAIKey,
-		"Anthropic":  NewAnthropicKey,
-		"K8s":        NewK8sToken,
-		"NPM":        NewNPMToken,
+		"AWSKeyID":  NewAWSKeyID,
+		"AWSSecret": NewAWSSecretKey,
+		"GitHub":    NewGitHubToken,
+		"Stripe":    NewStripeKey,
+		"OpenAI":    NewOpenAIKey,
+		"Anthropic": NewAnthropicKey,
+		"K8s":       NewK8sToken,
+		"NPM":       NewNPMToken,
 	}
 	for name, gen := range generators {
 		for i := 0; i < 50; i++ {

--- a/worker/index.js
+++ b/worker/index.js
@@ -51,6 +51,7 @@ const CANARY_TYPES = {
   npm:       { emoji: "📦", color: 0xCB3837, name: "npm"       },
   mcp:       { emoji: "🔌", color: 0x7C3AED, name: "MCP"       },
   pypi:      { emoji: "🐍", color: 0x3776AB, name: "PyPI"      },
+  "pypi-upload": { emoji: "📤", color: 0x3776AB, name: "PyPI Upload" },
   awsproc:   { emoji: "⚙️",  color: 0xFF9900, name: "AWS (credential_process)" },
   docker:    { emoji: "🐳", color: 0x2496ED, name: "Docker"    },
   generic:   { emoji: "🗝️",  color: 0x888888, name: "Generic"   },

--- a/worker/index.test.js
+++ b/worker/index.test.js
@@ -189,7 +189,7 @@ describe("shouldFilter", () => {
 describe("CANARY_TYPES completeness", () => {
   const EXPECTED_TYPES = [
     "aws", "awsproc", "gcp", "github", "stripe", "openai", "anthropic",
-    "ssh", "k8s", "npm", "mcp", "pypi", "docker", "generic",
+    "ssh", "k8s", "npm", "mcp", "pypi", "pypi-upload", "docker", "generic",
     "huggingface", "azure", "git", "terraform",
   ];
 


### PR DESCRIPTION
## Summary

- replace the Kubernetes shell exec credential plugin with a static fake bearer token and callback API server
- move the AWS endpoint canary to the supported shared-config location and prove it with AWS CLI
- promote Git and npm into the five-signal precision default and `snare prove`
- add a lower-noise named `.pypirc` upload canary and vendor-adjacent inert MCP placement
- retire unsupported Azure, Docker, GitHub CLI, and Stripe planting while preserving legacy manifest status and teardown
- classify every supported detection as real-client, manual-probe, or template-only and surface that status
- validate labels before interpolating them into URLs and config templates
- align docs and product claims with active-use detection rather than passive file reads

## Why

The prior catalog mixed client-proven detections with templates that relied on unsupported configuration behavior. This could create false confidence. Some high-value, low-noise signals were also excluded from the default despite real-client proof.

## Impact

This is intended for the next minor release:

- default precision mode grows from `awsproc`, `ssh`, and `k8s` to include `git` and `npm`
- new planting of `azure`, `docker`, `github`, and `stripe` is rejected with an explanation
- existing retired canaries remain visible and removable
- unusual unsafe labels are rejected
- Kubernetes bait no longer executes a planted shell command

## Validation

- `go test ./... -race -count=1`
- `go vet ./...`
- `go build ./...`
- Staticcheck 2026.1
- govulncheck v1.6.0: no called vulnerabilities
- Worker tests: 52/52
- `npm audit --audit-level=high`: 0 vulnerabilities
- `wrangler deploy --dry-run`
- CI now runs the real-client canary lab in strict mode
