### PR TITLE
Prepare v0.5.0 release candidate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,20 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Validate release tag and source
+        run: |
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc\.(0|[1-9][0-9]*))?$ ]]; then
+            echo "Unsupported release tag: ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "${GITHUB_SHA}" refs/remotes/origin/main; then
+            echo "Release tag must point to a commit on main" >&2
+            exit 1
+          fi
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -31,7 +44,25 @@ jobs:
           cache: npm
           cache-dependency-path: worker/package-lock.json
 
+      - name: Install GCP canary contract dependencies
+        run: |
+          python3 -m venv /tmp/snare-canary-lab
+          /tmp/snare-canary-lab/bin/python -m pip install \
+            google-auth==2.56.2 \
+            requests==2.34.2
+          echo "/tmp/snare-canary-lab/bin" >> "$GITHUB_PATH"
+
+      - name: Verify real-client canary dependencies
+        run: |
+          command -v aws
+          command -v git
+          command -v kubectl
+          command -v npm
+          command -v ssh
+
       - name: Run tests
+        env:
+          SNARE_CANARY_LAB_STRICT: "1"
         run: go test ./... -race -count=1
 
       - name: Vet
@@ -71,6 +102,9 @@ jobs:
               -ldflags="-s -w -X main.version=${RELEASE_VERSION}" \
               -o "dist/snare" \
               ./cmd/snare
+            if [[ "$target" == "linux/amd64" ]]; then
+              test "$(dist/snare --version)" = "snare ${RELEASE_VERSION}"
+            fi
             cd dist
             tar -czf "snare_${SUFFIX}.tar.gz" "snare"
             sha256sum "snare_${SUFFIX}.tar.gz" >> checksums.txt
@@ -100,4 +134,6 @@ jobs:
             dist/checksums.txt
             dist/checksums.txt.bundle
           generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          make_latest: ${{ contains(github.ref_name, '-') && 'false' || 'true' }}
           fail_on_unmatched_files: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning: [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+## [0.5.0-rc.1] - 2026-07-26
+
 ### Security
 - Validate labels against a cross-format-safe character set before interpolating them into callback paths and credential configuration templates.
 - Replace the Kubernetes shell-based exec credential plugin with a static fake bearer token and callback API server, preserving detection without executing planted shell commands.


### PR DESCRIPTION
## Summary

- cut the changelog for `v0.5.0-rc.1`
- validate release tag syntax and require release tags to point to commits on `main`
- run the real-client canary lab in strict mode during release builds
- verify required AWS, Git, Kubernetes, npm, SSH, and GCP proof clients before testing
- verify that the release version is embedded in the Linux AMD64 binary
- mark `-rc.*` GitHub releases as prereleases and prevent them from replacing the stable Latest release

## Why

The detection-hardening work merged in #72 is a minor-version behavioral change. The existing tag workflow would accept any `v*` tag and did not explicitly classify release-candidate tags as prereleases. It also allowed the external-client contract suite to skip unavailable clients during a release build.

## Release process

This PR prepares—but does not publish—`v0.5.0-rc.1`. After this PR is reviewed, green, and merged, the candidate can be published by tagging the merge commit:

```sh
git tag -s v0.5.0-rc.1 <merge-commit>
git push origin v0.5.0-rc.1
```

The tag-triggered workflow will build, test, sign, and publish the candidate assets as a GitHub prerelease.

## Validation

- workflow YAML parses successfully
- `git diff --check`
- `go test ./... -race -count=1`
- `go vet ./...`
- Worker: 52/52 tests
- `npm audit --audit-level=high`: 0 vulnerabilities
- `wrangler deploy --dry-run`
- native build reports `snare v0.5.0-rc.1`
- strict external-client proof is configured for GitHub Actions; the local Mac lacks AWS CLI and the pinned GCP Python client, so GitHub CI is the authoritative strict run
