### PR TITLE
Constrain release provenance verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,14 @@ jobs:
       - name: Sign checksums with cosign
         run: cosign sign-blob --yes dist/checksums.txt --bundle dist/checksums.txt.bundle
 
+      - name: Verify signed checksums
+        run: |
+          cosign verify-blob \
+            --bundle dist/checksums.txt.bundle \
+            --certificate-identity "https://github.com/${GITHUB_WORKFLOW_REF}" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            dist/checksums.txt
+
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:

--- a/README.md
+++ b/README.md
@@ -354,10 +354,15 @@ See the [self-hosting guide](docs/self-hosting.md) for reverse proxy, backup, up
 Release checksums are signed with [Sigstore/cosign](https://docs.sigstore.dev/) using keyless OIDC signing via GitHub Actions. To verify a downloaded release:
 
 ```sh
-cosign verify-blob --bundle checksums.txt.bundle checksums.txt
+snare_release_tag=v0.5.0 # replace with the exact tag you downloaded
+cosign verify-blob \
+  --bundle checksums.txt.bundle \
+  --certificate-identity "https://github.com/peg/snare/.github/workflows/release.yml@refs/tags/${snare_release_tag}" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  checksums.txt
 ```
 
-This confirms the checksums file was produced by the official GitHub Actions release workflow and has not been tampered with.
+This verifies both integrity and provenance: the checksums file must be unchanged, signed by Snare's official release workflow for that exact tag, and issued through GitHub Actions OIDC. After that succeeds, verify the archive itself with `sha256sum -c checksums.txt` on Linux or `shasum -a 256 -c checksums.txt` on macOS.
 
 ---
 

--- a/docs/enterprise-evaluation.md
+++ b/docs/enterprise-evaluation.md
@@ -121,9 +121,16 @@ See [Self-hosting](self-hosting.md).
 For production-like pilots, verify the release before installing broadly:
 
 ```sh
-cosign verify-blob --bundle checksums.txt.bundle checksums.txt
+snare_release_tag=v0.5.0 # replace with the exact tag under evaluation
+cosign verify-blob \
+  --bundle checksums.txt.bundle \
+  --certificate-identity "https://github.com/peg/snare/.github/workflows/release.yml@refs/tags/${snare_release_tag}" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  checksums.txt
 sha256sum -c checksums.txt
 ```
+
+On macOS, use `shasum -a 256 -c checksums.txt` for the archive checksum step.
 
 Then smoke-test the binary in a temporary install directory before deploying to endpoints:
 


### PR DESCRIPTION
## What changed

- verifies the newly signed checksum bundle inside the release workflow before publishing
- constrains verification to the exact Snare release workflow identity and GitHub Actions OIDC issuer
- updates README and enterprise guidance to bind verification to the exact downloaded tag
- documents the portable macOS checksum command

## Why

The previous `cosign verify-blob --bundle ...` examples checked the signature and bundle but did not state the expected signer identity or OIDC issuer. Explicit identity constraints are what establish that the artifact came from Snare's official release workflow rather than merely carrying a valid keyless signature.

## Validation

- `actionlint v1.7.7 .github/workflows/release.yml`
- Cosign v3.0.6 verified the actual v0.5.0 checksum bundle with the documented workflow identity and GitHub Actions issuer
- a wrong-tag identity was rejected in a negative test
- `git diff --check`

## Release impact

No release is triggered by this PR. The self-verification step will run on the next release tag before GitHub assets are published.