### PR TITLE
Add isolated Cloudflare Worker staging foundation

### DIFF
--- a/.github/workflows/deploy-worker-staging.yml
+++ b/.github/workflows/deploy-worker-staging.yml
@@ -1,0 +1,133 @@
+name: Deploy Staging Cloudflare Worker
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: snare-worker-staging
+  cancel-in-progress: true
+
+jobs:
+  worker:
+    name: Deploy and smoke-test staging Worker
+    if: >-
+      (github.event_name == 'workflow_dispatch' &&
+       github.ref == 'refs/heads/main') ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_branch == 'main' &&
+       github.event.workflow_run.head_repository.full_name == github.repository)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: snare-worker-staging
+      url: https://staging.snare.sh/health
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKER_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: worker/package-lock.json
+
+      - name: Install Worker dependencies
+        working-directory: worker
+        run: npm ci
+
+      - name: Audit Worker dependencies
+        working-directory: worker
+        run: npm audit --audit-level=high
+
+      - name: Test Worker
+        working-directory: worker
+        run: npm test
+
+      - name: Validate staging deployment bundle
+        working-directory: worker
+        run: npm run cf:check:staging
+
+      - name: Deploy staging Worker
+        id: deploy
+        working-directory: worker
+        env:
+          WRANGLER_OUTPUT_FILE: ${{ runner.temp }}/wrangler-output.jsonl
+        run: |
+          set -euo pipefail
+          : > "$WRANGLER_OUTPUT_FILE"
+          npx wrangler deploy \
+            --env staging \
+            --keep-vars \
+            --strict \
+            --message "GitHub Actions staging deploy of ${{ github.event.workflow_run.head_sha || github.sha }}"
+
+          version_id="$(
+            jq -r 'select(.type == "deploy") | .version_id // empty' \
+              "$WRANGLER_OUTPUT_FILE" | tail -n 1
+          )"
+          if [[ -z "$version_id" ]]; then
+            echo "Wrangler did not report the staging Worker version ID." >&2
+            cat "$WRANGLER_OUTPUT_FILE" >&2
+            exit 1
+          fi
+          echo "version_id=$version_id" >> "$GITHUB_OUTPUT"
+
+      - name: Verify exact staging version
+        env:
+          EXPECTED_VERSION_ID: ${{ steps.deploy.outputs.version_id }}
+        run: |
+          set -euo pipefail
+          observed_version_id="unavailable"
+          for attempt in {1..60}; do
+            if response="$(curl --fail --silent --show-error https://staging.snare.sh/health)"; then
+              observed_version_id="$(
+                jq -r '.version.id // "missing"' <<<"$response" 2>/dev/null \
+                  || printf 'invalid health response'
+              )"
+              if jq -e --arg expected "$EXPECTED_VERSION_ID" '
+                .status == "ok"
+                and .environment == "staging"
+                and .version.id == $expected
+                and (.version.timestamp | type == "string" and length > 0)
+              ' <<<"$response" >/dev/null; then
+                break
+              fi
+            fi
+
+            if [[ "$attempt" -eq 60 ]]; then
+              echo "Staging did not activate the deployed Worker version." >&2
+              printf 'Expected: %s\nObserved: %s\n' \
+                "$EXPECTED_VERSION_ID" "$observed_version_id" >&2
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - name: Run staging lifecycle smoke test
+        run: worker/scripts/smoke-staging.sh https://staging.snare.sh
+
+      - name: Summarize staging deployment
+        env:
+          VERSION_ID: ${{ steps.deploy.outputs.version_id }}
+          DEPLOY_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+        run: |
+          {
+            echo "## Staging deployment passed"
+            echo
+            printf -- '- Commit: `%s`\n' "$DEPLOY_SHA"
+            printf -- '- Active Worker version: `%s`\n' "$VERSION_ID"
+            echo '- Lifecycle smoke test: `passed`'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -63,7 +63,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          secrets="$(npx wrangler secret list --format json)"
+          secrets="$(npx wrangler secret list --env="" --format json)"
           jq -e 'any(.[]; .name == "WEBHOOK_URLS")' <<<"$secrets" >/dev/null
           echo "Cloudflare access and WEBHOOK_URLS configuration verified."
 
@@ -85,7 +85,7 @@ jobs:
             echo "## Deployment before this run"
             echo
             echo '```text'
-            npx wrangler deployments list
+            npx wrangler deployments list --env=""
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -157,8 +157,8 @@ jobs:
             echo "## Deployment after this run"
             echo
             echo '```text'
-            npx wrangler deployments list
+            npx wrangler deployments list --env=""
             echo '```'
             echo
-            echo "Rollback with \`cd worker && npx wrangler rollback\`."
+            echo "Rollback with \`cd worker && npx wrangler rollback --env=\`."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -1,0 +1,52 @@
+# Managed Worker staging
+
+The managed callback service has an isolated Cloudflare staging environment:
+
+- Worker: `snare-callback-staging`
+- Hostname: `https://staging.snare.sh`
+- KV namespace: `snare-events-staging`
+- GitHub environment: `snare-worker-staging`
+
+The staging Worker never binds production KV. Its runtime secrets must also be
+staging-only; do not copy production webhook destinations into staging.
+
+## Deployment flow
+
+After CI succeeds for a commit on `main`, the staging workflow deploys that
+exact commit, waits for `/health` to report the exact new Cloudflare version,
+and runs a synthetic lifecycle test:
+
+1. Create a staging device.
+2. Register a `snare-test-*` token.
+3. Trigger its callback.
+4. Read the stored event with device authentication.
+5. Revoke the token and remove the synthetic device and event keys.
+
+The workflow can also be dispatched manually. Production remains a separate,
+manually dispatched workflow protected by `snare-worker-production`.
+
+## Required GitHub environment configuration
+
+Create `snare-worker-staging` in repository settings with:
+
+- environment secret `CLOUDFLARE_WORKER_API_TOKEN`;
+- environment variable `CLOUDFLARE_ACCOUNT_ID`;
+- deployment branches restricted to `main`.
+
+Use a dedicated staging token scoped to this Cloudflare account with only
+`Workers Scripts: Edit` and `Workers KV Storage: Edit`. The latter is required
+because the smoke test deletes its synthetic KV records after verification.
+The staging custom domain is managed by the Workers Scripts permission; DNS
+Edit and broad zone permissions are not required.
+
+## Optional staging webhook
+
+The lifecycle test proves registration, callback ingestion, KV storage, and
+authenticated event reads without requiring an outbound webhook. To exercise
+delivery manually, set the staging Worker's `WEBHOOK_URLS` secret to a dedicated
+non-production destination:
+
+```sh
+cd worker
+npx wrangler secret put WEBHOOK_URLS --env staging
+```

--- a/worker/index.js
+++ b/worker/index.js
@@ -142,6 +142,7 @@ export default {
       const version = env.CF_VERSION_METADATA;
       return json({
         status: "ok",
+        environment: env.SNARE_ENVIRONMENT || "production",
         version: {
           id: version.id,
           tag: version.tag,

--- a/worker/index.test.js
+++ b/worker/index.test.js
@@ -46,7 +46,29 @@ describe("health", () => {
     expect(response.headers.get("cache-control")).toBe("no-store, max-age=0");
     expect(await response.json()).toMatchObject({
       status: "ok",
+      environment: "production",
       version,
+    });
+  });
+
+  it("identifies the staging environment", async () => {
+    const response = await worker.fetch(
+      new Request("https://staging.snare.sh/health"),
+      {
+        CF_VERSION_METADATA: {
+          id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+          tag: "staging",
+          timestamp: "2026-07-27T00:00:00.000Z",
+        },
+        SNARE_ENVIRONMENT: "staging",
+      },
+      { waitUntil() {} },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      status: "ok",
+      environment: "staging",
     });
   });
 });

--- a/worker/package.json
+++ b/worker/package.json
@@ -4,8 +4,10 @@
   "type": "module",
   "scripts": {
     "test": "vitest run",
-    "cf:check": "wrangler deploy --dry-run",
-    "cf:deploy": "wrangler deploy --keep-vars --strict"
+    "cf:check": "wrangler deploy --dry-run --env=",
+    "cf:check:staging": "wrangler deploy --dry-run --env staging",
+    "cf:deploy": "wrangler deploy --env= --keep-vars --strict",
+    "cf:deploy:staging": "wrangler deploy --env staging --keep-vars --strict"
   },
   "devDependencies": {
     "vitest": "4.1.10",

--- a/worker/scripts/smoke-staging.sh
+++ b/worker/scripts/smoke-staging.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+set -eu
+
+base_url="${1:-https://staging.snare.sh}"
+worker_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+device_secret=$(openssl rand -hex 32)
+token_id="snare-test-$(openssl rand -hex 12)"
+device_id=""
+
+case "$base_url" in
+  https://*) ;;
+  *) echo "staging base URL must use HTTPS" >&2; exit 1 ;;
+esac
+
+for command_name in curl jq openssl; do
+  command -v "$command_name" >/dev/null 2>&1 || {
+    echo "missing required command: $command_name" >&2
+    exit 1
+  }
+done
+
+cleanup() {
+  if [ -z "$device_id" ]; then
+    return
+  fi
+
+  revoke_payload=$(jq -nc \
+    --arg token_id "$token_id" \
+    --arg device_id "$device_id" \
+    '{token_id: $token_id, device_id: $device_id}')
+  curl -fsS \
+    -H "Authorization: Bearer $device_secret" \
+    -H "Content-Type: application/json" \
+    --data "$revoke_payload" \
+    "$base_url/api/revoke" >/dev/null 2>&1 || true
+
+  event_keys=$(
+    cd "$worker_dir"
+    npx wrangler kv key list \
+      --binding SNARE_KV \
+      --env staging \
+      --remote \
+      --prefix "event:$token_id:" 2>/dev/null \
+      | jq -r '.[].name' 2>/dev/null || true
+  )
+  for event_key in $event_keys; do
+    (
+      cd "$worker_dir"
+      npx wrangler kv key delete "$event_key" \
+        --binding SNARE_KV \
+        --env staging \
+        --remote >/dev/null 2>&1
+    ) || true
+  done
+
+  (
+    cd "$worker_dir"
+    npx wrangler kv key delete "device:$device_id" \
+      --binding SNARE_KV \
+      --env staging \
+      --remote >/dev/null 2>&1
+  ) || true
+}
+trap cleanup EXIT
+trap 'exit 130' HUP INT TERM
+
+device_payload=$(jq -nc --arg secret "$device_secret" '{device_secret: $secret}')
+device_response=$(curl -fsS \
+  -H "Content-Type: application/json" \
+  --data "$device_payload" \
+  "$base_url/api/devices")
+device_id=$(printf '%s' "$device_response" | jq -er '.device_id')
+
+register_payload=$(jq -nc \
+  --arg token_id "$token_id" \
+  --arg device_id "$device_id" \
+  '{
+    token_id: $token_id,
+    webhook_url: "use-global",
+    device_id: $device_id,
+    canary_type: "generic",
+    label: "staging-e2e"
+  }')
+curl -fsS \
+  -H "Authorization: Bearer $device_secret" \
+  -H "Content-Type: application/json" \
+  --data "$register_payload" \
+  "$base_url/api/register" >/dev/null
+
+curl -fsS \
+  -A "Snare-Staging-Smoke/1.0" \
+  "$base_url/c/$token_id" >/dev/null
+
+attempt=1
+while [ "$attempt" -le 30 ]; do
+  if events_response=$(curl -fsS \
+    -H "Authorization: Bearer $device_secret" \
+    -H "X-Snare-Device-ID: $device_id" \
+    "$base_url/api/events/$token_id" 2>/dev/null); then
+    if printf '%s' "$events_response" | jq -e --arg token "$token_id" '
+      .events | any(.token == $token and .is_test == true)
+    ' >/dev/null; then
+      echo "Staging registration, callback, storage, and authenticated event read passed."
+      exit 0
+    fi
+  fi
+  attempt=$((attempt + 1))
+  sleep 2
+done
+
+echo "Staging event did not become readable within 60 seconds." >&2
+exit 1

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -27,6 +27,34 @@
   ],
   "version_metadata": {
     "binding": "CF_VERSION_METADATA"
+  },
+  "env": {
+    "staging": {
+      "name": "snare-callback-staging",
+      "routes": [
+        {
+          "pattern": "staging.snare.sh",
+          "custom_domain": true
+        }
+      ],
+      "kv_namespaces": [
+        {
+          "binding": "SNARE_KV",
+          "id": "64c03175839d4983b6d54649dec5dcf1"
+        }
+      ],
+      "version_metadata": {
+        "binding": "CF_VERSION_METADATA"
+      },
+      "vars": {
+        "SNARE_ENVIRONMENT": "staging"
+      },
+      "observability": {
+        "enabled": true,
+        "head_sampling_rate": 1
+      }
+    }
   }
-  // WEBHOOK_URLS remains a remote Worker secret and is never committed.
+  // WEBHOOK_URLS remains a remote Worker secret and is never committed. If
+  // configured for staging, it must point to a dedicated non-production sink.
 }


### PR DESCRIPTION
## Summary

- add an isolated `snare-callback-staging` Worker at `staging.snare.sh`
- bind a dedicated `snare-events-staging` KV namespace, never production KV
- deploy automatically only after CI succeeds for a `main` push (or manual dispatch from `main`)
- verify the exact activated Worker version through `/health`
- run and clean up a synthetic device/register/callback/event-read lifecycle test
- make production Wrangler commands explicitly target the top-level environment
- document GitHub environment setup and least-privilege Cloudflare permissions

## Required before merge

Configure the GitHub environment `snare-worker-staging` with:

- secret `CLOUDFLARE_WORKER_API_TOKEN`
- variable `CLOUDFLARE_ACCOUNT_ID`
- deployment branches restricted to `main`

The token needs only account-level `Workers Scripts: Edit` and `Workers KV Storage: Edit` for this account. Do not add production webhook destinations to staging.

## Validation

- `go vet ./...`
- `go test ./... -race -count=1`
- Worker tests: 53/53 pass
- `npm audit --audit-level=high`: 0 vulnerabilities
- production Wrangler dry-run: passes and binds production KV
- staging Wrangler dry-run: passes and binds staging KV plus `SNARE_ENVIRONMENT=staging`
- smoke script shell syntax and `git diff --check`: pass

No production deployment is performed by this PR.