### PR TITLE
Fix Wrangler deployment output capture

### DIFF
--- a/.github/workflows/deploy-worker-staging.yml
+++ b/.github/workflows/deploy-worker-staging.yml
@@ -64,10 +64,10 @@ jobs:
         id: deploy
         working-directory: worker
         env:
-          WRANGLER_OUTPUT_FILE: ${{ runner.temp }}/wrangler-output.jsonl
+          WRANGLER_OUTPUT_FILE_PATH: ${{ runner.temp }}/wrangler-output.jsonl
         run: |
           set -euo pipefail
-          : > "$WRANGLER_OUTPUT_FILE"
+          : > "$WRANGLER_OUTPUT_FILE_PATH"
           npx wrangler deploy \
             --env staging \
             --keep-vars \
@@ -76,11 +76,11 @@ jobs:
 
           version_id="$(
             jq -r 'select(.type == "deploy") | .version_id // empty' \
-              "$WRANGLER_OUTPUT_FILE" | tail -n 1
+              "$WRANGLER_OUTPUT_FILE_PATH" | tail -n 1
           )"
           if [[ -z "$version_id" ]]; then
             echo "Wrangler did not report the staging Worker version ID." >&2
-            cat "$WRANGLER_OUTPUT_FILE" >&2
+            cat "$WRANGLER_OUTPUT_FILE_PATH" >&2
             exit 1
           fi
           echo "version_id=$version_id" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -94,19 +94,19 @@ jobs:
         id: deploy
         working-directory: worker
         env:
-          WRANGLER_OUTPUT_FILE: ${{ runner.temp }}/wrangler-output.jsonl
+          WRANGLER_OUTPUT_FILE_PATH: ${{ runner.temp }}/wrangler-output.jsonl
         run: |
           set -euo pipefail
-          : > "$WRANGLER_OUTPUT_FILE"
+          : > "$WRANGLER_OUTPUT_FILE_PATH"
           npm run cf:deploy -- --message "GitHub Actions deploy of ${{ github.sha }}"
 
           version_id="$(
             jq -r 'select(.type == "deploy") | .version_id // empty' \
-              "$WRANGLER_OUTPUT_FILE" | tail -n 1
+              "$WRANGLER_OUTPUT_FILE_PATH" | tail -n 1
           )"
           if [[ -z "$version_id" ]]; then
             echo "Wrangler did not report the deployed Worker version ID." >&2
-            cat "$WRANGLER_OUTPUT_FILE" >&2
+            cat "$WRANGLER_OUTPUT_FILE_PATH" >&2
             exit 1
           fi
           echo "version_id=$version_id" >> "$GITHUB_OUTPUT"

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -33,11 +33,16 @@ Create `snare-worker-staging` in repository settings with:
 - environment variable `CLOUDFLARE_ACCOUNT_ID`;
 - deployment branches restricted to `main`.
 
-Use a dedicated staging token scoped to this Cloudflare account with only
-`Workers Scripts: Edit` and `Workers KV Storage: Edit`. The latter is required
-because the smoke test deletes its synthetic KV records after verification.
-The staging custom domain is managed by the Workers Scripts permission; DNS
-Edit and broad zone permissions are not required.
+Use a dedicated staging token with:
+
+- account-scoped `Workers Scripts: Edit`;
+- account-scoped `Workers KV Storage: Edit`; and
+- zone-scoped `Workers Routes: Edit` restricted to `snare.sh`.
+
+KV write access is required because the smoke test deletes its synthetic
+records after verification. Wrangler also reconciles Worker routes during a
+deploy, including when the configured target is a custom domain. DNS Edit and
+broad access to other zones are not required.
 
 ## Optional staging webhook
 


### PR DESCRIPTION
## Summary

- use Wrangler's supported `WRANGLER_OUTPUT_FILE_PATH` variable in both staging and production deployment workflows
- preserve exact deployed-version extraction from Wrangler's JSONL output
- document the zone-scoped `Workers Routes: Edit` permission Wrangler needs to reconcile the `snare.sh` staging route

## Root cause

The staging Worker deployment itself succeeded, but the workflow exported `WRANGLER_OUTPUT_FILE`, which Wrangler ignores. The workflow then parsed the empty file it had pre-created and incorrectly reported that no version ID was available.

The deployed staging Worker is healthy at `https://staging.snare.sh/health`; this PR fixes workflow bookkeeping so the version assertion and lifecycle smoke test can proceed after merge.

## Validation

- `actionlint .github/workflows/deploy-worker.yml .github/workflows/deploy-worker-staging.yml`
- `git diff --check`
- `sh -n worker/scripts/smoke-staging.sh`
- Wrangler 4.114.0 staging dry run completed and emitted both `wrangler-session` and `deploy` JSONL records through `WRANGLER_OUTPUT_FILE_PATH`

No production or staging deployment was performed from this branch.