### PR TITLE
Require staging-qualified production deploys

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -4,15 +4,20 @@ on:
   workflow_dispatch:
     inputs:
       operation:
-        description: Validate access or deploy the selected ref
+        description: Validate access or deploy a staging-qualified commit
         required: true
         type: choice
         default: validate
         options:
           - validate
           - deploy
+      commit_sha:
+        description: Exact 40-character commit SHA from main
+        required: true
+        type: string
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -27,14 +32,76 @@ jobs:
     environment:
       name: snare-worker-production
       url: https://snare.sh/health
-    env:
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKER_API_TOKEN }}
-      CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ inputs.commit_sha }}
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Verify production source and staging qualification
+        id: qualify
+        env:
+          DEPLOY_OPERATION: ${{ inputs.operation }}
+          DEPLOY_SHA: ${{ inputs.commit_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "Production workflow must be dispatched from main." >&2
+            exit 1
+          fi
+          if [[ ! "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "commit_sha must be an exact lowercase 40-character commit SHA." >&2
+            exit 1
+          fi
+          if [[ "$(git rev-parse HEAD)" != "$DEPLOY_SHA" ]]; then
+            echo "Checked-out commit does not match commit_sha." >&2
+            exit 1
+          fi
+
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "$DEPLOY_SHA" FETCH_HEAD; then
+            echo "Production commit must belong to main." >&2
+            exit 1
+          fi
+
+          echo "deploy_sha=$DEPLOY_SHA" >> "$GITHUB_OUTPUT"
+          if [[ "$DEPLOY_OPERATION" != "deploy" ]]; then
+            exit 0
+          fi
+
+          runs_url="${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/workflows/deploy-worker-staging.yml/runs"
+          response="$(curl --fail-with-body --silent --show-error \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            --get \
+            --data-urlencode "event=workflow_run" \
+            --data-urlencode "status=success" \
+            --data-urlencode "head_sha=${DEPLOY_SHA}" \
+            --data-urlencode "per_page=100" \
+            "$runs_url")"
+          staging_run_url="$(jq -r --arg sha "$DEPLOY_SHA" '
+            [.workflow_runs[]
+              | select(
+                  .head_sha == $sha and
+                  .event == "workflow_run" and
+                  .conclusion == "success"
+                )]
+            | sort_by(.run_number)
+            | last
+            | .html_url // empty
+          ' <<<"$response")"
+          if [[ -z "$staging_run_url" ]]; then
+            echo "No successful automatic staging run found for ${DEPLOY_SHA}." >&2
+            exit 1
+          fi
+
+          echo "staging_run_url=$staging_run_url" >> "$GITHUB_OUTPUT"
+          echo "Qualified by staging run: $staging_run_url"
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -61,6 +128,9 @@ jobs:
       - name: Verify Cloudflare access and production secret
         working-directory: worker
         shell: bash
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKER_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           set -euo pipefail
           secrets="$(npx wrangler secret list --env="" --format json)"
@@ -70,17 +140,21 @@ jobs:
       - name: Record current deployment
         working-directory: worker
         env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKER_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           DEPLOY_OPERATION: ${{ inputs.operation }}
-          DEPLOY_REF: ${{ github.ref_name }}
-          DEPLOY_SHA: ${{ github.sha }}
+          DEPLOY_SHA: ${{ steps.qualify.outputs.deploy_sha }}
+          STAGING_RUN_URL: ${{ steps.qualify.outputs.staging_run_url }}
         run: |
           set -euo pipefail
           {
             echo "## Deployment input"
             echo
             printf -- '- Operation: `%s`\n' "$DEPLOY_OPERATION"
-            printf -- '- Ref: `%s`\n' "$DEPLOY_REF"
             printf -- '- Commit: `%s`\n' "$DEPLOY_SHA"
+            if [[ -n "$STAGING_RUN_URL" ]]; then
+              printf -- '- Qualifying staging run: %s\n' "$STAGING_RUN_URL"
+            fi
             echo
             echo "## Deployment before this run"
             echo
@@ -94,11 +168,14 @@ jobs:
         id: deploy
         working-directory: worker
         env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKER_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          DEPLOY_SHA: ${{ steps.qualify.outputs.deploy_sha }}
           WRANGLER_OUTPUT_FILE_PATH: ${{ runner.temp }}/wrangler-output.jsonl
         run: |
           set -euo pipefail
           : > "$WRANGLER_OUTPUT_FILE_PATH"
-          npm run cf:deploy -- --message "GitHub Actions deploy of ${{ github.sha }}"
+          npm run cf:deploy -- --message "GitHub Actions deploy of ${DEPLOY_SHA}"
 
           version_id="$(
             jq -r 'select(.type == "deploy") | .version_id // empty' \
@@ -150,6 +227,9 @@ jobs:
       - name: Record deployed version and rollback command
         if: inputs.operation == 'deploy'
         working-directory: worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKER_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           set -euo pipefail
           {

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -22,8 +22,30 @@ and runs a synthetic lifecycle test:
 4. Read the stored event with device authentication.
 5. Revoke the token and remove the synthetic device and event keys.
 
-The workflow can also be dispatched manually. Production remains a separate,
-manually dispatched workflow protected by `snare-worker-production`.
+The workflow can also be dispatched manually. A manual staging run is useful
+for diagnosis, but it does not qualify a commit for production because it is
+not chained to a successful `CI` push run.
+
+## Production promotion
+
+Production remains a separate, manually dispatched workflow protected by
+`snare-worker-production`. To deploy:
+
+1. Copy the exact 40-character commit SHA from `main`.
+2. Confirm the automatic staging workflow for that commit passed.
+3. Dispatch `Deploy Cloudflare Worker` from the `main` branch, choose `deploy`,
+   and enter that commit SHA.
+4. If a reviewer gate is configured, approve the protected production
+   environment deployment when prompted.
+
+The production workflow checks out the requested commit, proves that it belongs
+to `main`, and uses the GitHub Actions API to require a successful automatic
+staging run for that exact SHA. A successful manual staging run does not satisfy
+the gate. Production then reports and verifies the exact Cloudflare Worker
+version that became active.
+
+Use `validate` with a `main` commit SHA to test the production credentials and
+deployment bundle without requiring a staging run or changing production.
 
 ## Required GitHub environment configuration
 
@@ -43,6 +65,12 @@ KV write access is required because the smoke test deletes its synthetic
 records after verification. Wrangler also reconciles Worker routes during a
 deploy, including when the configured target is a custom domain. DNS Edit and
 broad access to other zones are not required.
+
+Configure `snare-worker-production` separately with its production-scoped
+Cloudflare token and account ID, restrict deployments to `main`, and require an
+environment reviewer when the repository has a second trusted maintainer. The
+workflow exposes the Cloudflare credentials only to the steps that inspect or
+change the production Worker.
 
 ## Optional staging webhook
 


### PR DESCRIPTION
## Summary

- require production workflow dispatches to name an exact 40-character commit SHA from `main`
- require deploy operations to find a successful automatic staging run for that exact commit
- exclude manually dispatched staging runs from production qualification
- check out and deploy the qualified commit rather than the workflow dispatch ref implicitly
- scope Cloudflare credentials to only the production steps that require them
- document the staging-to-production promotion procedure and environment protections

## Security and operational impact

Production can no longer deploy an arbitrary selected ref that merely passes the production workflow's local checks. A deployment must use a commit on `main` whose CI-gated staging deployment completed successfully, including exact-version activation and the lifecycle smoke test.

The workflow still permits `validate` for a `main` commit without a staging run because validation does not change production. Cloudflare credentials are no longer inherited by dependency installation, tests, or unrelated setup steps.

## Validation

- all Go tests pass with the race detector
- `go vet ./...`
- 53 Worker tests pass
- Wrangler production deployment dry run passes
- actionlint passes for every workflow
- `git diff --check`
- live GitHub API positive check resolves merge commit `bd81957…` to staging run 3
- live negative check returns no qualifying run for an unstaged commit

This PR does not deploy either Worker.