### PR TITLE
Add durable webhook delivery foundation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -82,6 +82,13 @@ Device IDs are server-assigned via `POST /api/devices` — clients cannot choose
 3. Fire all webhooks in parallel via `Promise.allSettled`
 4. Failures logged to CF Workers Logs but don't affect the response
 
+The repository contains a tested v1 message contract as a non-active foundation
+for durable delivery. The current Worker has no queue binding, does not enqueue
+messages, and continues to use the direct flow above. The queue topology,
+privacy boundary, retry policy, self-hosting constraint, and activation gates
+are documented in
+[Durable webhook delivery](docs/webhook-delivery.md).
+
 Outbound webhook requests include `X-Snare-Signature: sha256=<hmac>` when the Cloudflare Worker `WEBHOOK_SIGNING_SECRET` secret is configured. Receivers can verify alerts came from the configured Snare callback deployment.
 
 **Supported webhook formats:** Discord (embed), Slack (attachment), Telegram (HTML), generic JSON (`event: "canary.fired"`).

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ These docs are written for security engineers evaluating, piloting, or operating
 
 - [Enterprise evaluation](enterprise-evaluation.md) — data flow, files touched, safe pilot checklist, proof artifact workflow, and limitations.
 - [Self-hosting](self-hosting.md) — Docker Compose, `snare serve`, Cloudflare Worker deployment notes, reverse proxy guidance, backups, and upgrades.
+- [Durable webhook delivery](webhook-delivery.md) — queue topology, privacy-preserving message contract, retry policy, and rollout gates.
 - [Generic webhooks](integrations/generic-webhook.md) — event schema, signature verification, and relay guidance.
 - [Splunk integration](integrations/splunk.md) — Splunk HEC relay pattern and field mapping.
 - [Datadog integration](integrations/datadog.md) — direct Logs intake and monitor examples.

--- a/docs/webhook-delivery.md
+++ b/docs/webhook-delivery.md
@@ -1,0 +1,101 @@
+# Durable webhook delivery
+
+Snare is adopting Cloudflare Queues to separate callback ingestion from
+outbound webhook availability. This document defines the resource topology,
+message boundary, and rollout gates before queue delivery becomes active.
+
+## Current rollout status
+
+The managed Cloudflare account contains four isolated queues:
+
+| Environment | Delivery queue | Dead-letter queue |
+|---|---|---|
+| Production | `snare-webhook-delivery` | `snare-webhook-delivery-dlq` |
+| Staging | `snare-webhook-delivery-staging` | `snare-webhook-delivery-staging-dlq` |
+
+The managed queues are not bound to the Worker yet: webhook delivery remains
+direct and the queues remain empty. A follow-up behavioral change will add the
+environment-specific `WEBHOOK_DELIVERY_QUEUE` producer and consumer paths
+together with lifecycle tests. Keeping the inactive binding out of the default
+configuration avoids imposing a new resource requirement on self-hosters.
+
+## Delivery message v1
+
+Queue delivery is at least once. Snare will generate one stable delivery ID for
+each destination attempt chain and preserve it across retries. Receivers will
+get the ID in `X-Snare-Delivery-ID` so they can deduplicate rare redeliveries.
+
+The serialized message contract is:
+
+```json
+{
+  "schema": "snare.webhook-delivery.v1",
+  "delivery_id": "00000000-0000-4000-8000-000000000000",
+  "queued_at": "2026-07-30T00:00:00.000Z",
+  "destination_id": "sha256:<hex digest>",
+  "event": {},
+  "meta": {
+    "canaryType": "awsproc",
+    "label": "agent-prod-admin",
+    "deviceId": "dev-..."
+  }
+}
+```
+
+`destination_id` is a one-way digest used to match the queued delivery to a
+currently allowed destination. The message never contains the raw webhook URL.
+The consumer must resolve the current registration again, apply the outbound
+allowlist again, and cancel delivery if the destination was revoked or changed.
+
+The message must never contain:
+
+- the incoming callback request body;
+- authorization or credential header values;
+- a raw webhook URL;
+- a device secret; or
+- a webhook-signing secret.
+
+The `event` object remains the metadata-only event already stored by Snare. The
+consumer formats and signs the outbound payload only after dequeuing it.
+
+## Consumer policy
+
+The activation change must process each message independently:
+
+- acknowledge a successful `2xx` delivery;
+- retry network failures, timeouts, `408`, `425`, `429`, and `5xx` responses;
+- bound any receiver-provided retry delay;
+- avoid retrying permanent `4xx` responses indefinitely;
+- continue rejecting redirects; and
+- route exhausted failures to the environment-specific dead-letter queue.
+
+Logs may include the delivery ID, attempt count, provider class, safe status or
+error category, and latency. They must redact the token, IP, raw destination,
+payload, and secrets.
+
+## Activation gates
+
+Queue-backed delivery must not reach production until staging proves:
+
+1. successful delivery is acknowledged;
+2. `429`, temporary `5xx`, and timeout failures recover through retry;
+3. permanent failure reaches the dead-letter path;
+4. a redelivery preserves its delivery ID;
+5. redirects remain blocked;
+6. callback bodies and destination secrets do not appear in logs or messages;
+7. the existing registration, callback, storage, event-read, and cleanup smoke
+   test still passes; and
+8. the exact staging-qualified commit is promoted through the protected
+   production workflow.
+
+## Deployment prerequisites
+
+Before queue-backed behavior is activated, both `snare-worker-staging` and
+`snare-worker-production` GitHub environment tokens need account-scoped
+`Queues Edit` in addition to their existing Worker, KV, and route permissions.
+Keep the tokens restricted to the Snare account and retain their existing
+expiration.
+
+The dead-letter queues intentionally have no consumer during the first rollout.
+That preserves failed messages for inspection instead of creating an untested
+automatic replay loop.

--- a/worker/delivery.js
+++ b/worker/delivery.js
@@ -1,0 +1,85 @@
+const DELIVERY_SCHEMA = "snare.webhook-delivery.v1";
+
+const EVENT_FIELDS = [
+  "token",
+  "device_id",
+  "is_test",
+  "timestamp",
+  "ip",
+  "userAgent",
+  "method",
+  "path",
+  "country",
+  "city",
+  "asn",
+  "asnOrg",
+  "botScore",
+];
+
+const META_FIELDS = ["canaryType", "label", "deviceId"];
+
+const SDK_HINT_FIELDS = [
+  "amzSdkRequest",
+  "amzTarget",
+  "contentType",
+  "hasAwsSig",
+  "isPost",
+];
+
+function pickFields(source, fields) {
+  const picked = {};
+  for (const field of fields) {
+    if (source?.[field] !== undefined) picked[field] = source[field];
+  }
+  return picked;
+}
+
+async function sha256Hex(value) {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  );
+  return Array.from(new Uint8Array(digest))
+    .map(byte => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * Build the privacy-bounded v1 message used by durable webhook delivery.
+ *
+ * This module is deliberately not connected to the callback path yet. The
+ * activation change will validate the destination against the outbound policy,
+ * enqueue this message, and resolve the destination again in the consumer.
+ */
+async function createDeliveryMessage(
+  destinationURL,
+  event,
+  meta = {},
+  { deliveryId = crypto.randomUUID(), queuedAt = new Date().toISOString() } = {},
+) {
+  const destination = new URL(destinationURL);
+  if (
+    destination.protocol !== "https:" ||
+    destination.username ||
+    destination.password
+  ) {
+    throw new Error("webhook destination must use https without credentials");
+  }
+  destination.hash = "";
+
+  const queuedEvent = pickFields(event, EVENT_FIELDS);
+  if (event?.sdkHints !== undefined) {
+    queuedEvent.sdkHints = pickFields(event.sdkHints, SDK_HINT_FIELDS);
+  }
+
+  return {
+    schema: DELIVERY_SCHEMA,
+    delivery_id: deliveryId,
+    queued_at: queuedAt,
+    destination_id: `sha256:${await sha256Hex(destination.href)}`,
+    event: queuedEvent,
+    meta: pickFields(meta, META_FIELDS),
+  };
+}
+
+export { createDeliveryMessage, DELIVERY_SCHEMA };

--- a/worker/delivery.test.js
+++ b/worker/delivery.test.js
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { createDeliveryMessage, DELIVERY_SCHEMA } from "./delivery.js";
+
+describe("durable webhook delivery contract", () => {
+  it("creates a deterministic v1 envelope without serializing the destination", async () => {
+    const destination = "https://hooks.slack.com/services/T000/B000/secret";
+    const message = await createDeliveryMessage(
+      destination,
+      {
+        token: "agent-prod-12345678",
+        device_id: "dev-12345678",
+        is_test: false,
+        timestamp: "2026-07-30T00:00:00.000Z",
+        ip: "203.0.113.10",
+        method: "GET",
+        sdkHints: {
+          isPost: false,
+          hasAwsSig: true,
+          authorization: "must never be queued",
+        },
+        body: "must never be queued",
+        authorization: "must never be queued",
+      },
+      {
+        canaryType: "awsproc",
+        label: "agent-prod-admin",
+        deviceId: "dev-12345678",
+        webhookURL: destination,
+        deviceSecret: "must never be queued",
+      },
+      {
+        deliveryId: "00000000-0000-4000-8000-000000000000",
+        queuedAt: "2026-07-30T00:00:01.000Z",
+      },
+    );
+
+    expect(message).toMatchObject({
+      schema: DELIVERY_SCHEMA,
+      delivery_id: "00000000-0000-4000-8000-000000000000",
+      queued_at: "2026-07-30T00:00:01.000Z",
+      destination_id: expect.stringMatching(/^sha256:[0-9a-f]{64}$/),
+      event: {
+        token: "agent-prod-12345678",
+        device_id: "dev-12345678",
+        is_test: false,
+        timestamp: "2026-07-30T00:00:00.000Z",
+        ip: "203.0.113.10",
+        method: "GET",
+        sdkHints: {
+          hasAwsSig: true,
+          isPost: false,
+        },
+      },
+      meta: {
+        canaryType: "awsproc",
+        label: "agent-prod-admin",
+        deviceId: "dev-12345678",
+      },
+    });
+
+    const serialized = JSON.stringify(message);
+    expect(serialized).not.toContain(destination);
+    expect(serialized).not.toContain("must never be queued");
+    expect(message.event).not.toHaveProperty("body");
+    expect(message.event).not.toHaveProperty("authorization");
+    expect(message.event.sdkHints).not.toHaveProperty("authorization");
+    expect(message.meta).not.toHaveProperty("webhookURL");
+    expect(message.meta).not.toHaveProperty("deviceSecret");
+  });
+
+  it("uses stable destination identities and unique default delivery IDs", async () => {
+    const destination = "https://example.com/snare-webhook/secret";
+    const first = await createDeliveryMessage(destination, {});
+    const second = await createDeliveryMessage(destination, {});
+
+    expect(first.destination_id).toBe(second.destination_id);
+    expect(first.delivery_id).not.toBe(second.delivery_id);
+    expect(first.delivery_id).toMatch(/^[0-9a-f-]{36}$/);
+
+    const withFragment = await createDeliveryMessage(
+      `${destination}#not-sent-over-http`,
+      {},
+    );
+    expect(withFragment.destination_id).toBe(first.destination_id);
+  });
+
+  it("rejects non-HTTPS destinations", async () => {
+    await expect(
+      createDeliveryMessage("http://example.com/webhook", {}),
+    ).rejects.toThrow("webhook destination must use https without credentials");
+  });
+
+  it("rejects destinations containing URL credentials", async () => {
+    await expect(
+      createDeliveryMessage("https://user:secret@example.com/webhook", {}),
+    ).rejects.toThrow("webhook destination must use https without credentials");
+  });
+});


### PR DESCRIPTION
## Summary

- define a privacy-bounded, versioned queue message contract for durable webhook delivery
- document production/staging queue topology, retry policy, activation gates, and self-hosting constraints
- test that callback bodies, authorization values, raw webhook URLs, device secrets, and unrecognized nested SDK hints cannot enter messages
- identify destinations only by a normalized SHA-256 digest and reject non-HTTPS or credential-bearing URLs

## Rollout status

This PR does **not** change runtime webhook behavior. It adds no Worker import, queue binding, producer, or consumer. Direct delivery remains active.

The following empty Cloudflare resources have been created for the managed deployment:

- `snare-webhook-delivery`
- `snare-webhook-delivery-dlq`
- `snare-webhook-delivery-staging`
- `snare-webhook-delivery-staging-dlq`

Keeping queue bindings out of this foundation PR avoids imposing a new Cloudflare resource requirement on public self-hosters. A follow-up activation PR will add producer and consumer behavior together, with an optional/self-host-compatible configuration.

Before activation, the GitHub environment tokens for `snare-worker-staging` and `snare-worker-production` must receive account-scoped `Queues Edit`.

## Verification

- `npm test`: 57/57 passed
- `npm audit --audit-level=high`: 0 vulnerabilities
- `npm run cf:check`: passed; production bundle has no queue binding
- `npm run cf:check:staging`: passed; staging bundle has no queue binding
- `go test ./... -v -race -count=1`: passed (optional local canary clients unavailable locally; CI installs/verifies them)
- `go vet ./...`: passed
- `go build ./...`: passed
- `govulncheck ./...`: 0 called vulnerabilities
- `git diff --check`: passed