### PR TITLE
Override vulnerable undici dependency

### DIFF
--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -2428,9 +2428,9 @@
       "optional": true
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/worker/package.json
+++ b/worker/package.json
@@ -12,5 +12,8 @@
   "devDependencies": {
     "vitest": "4.1.10",
     "wrangler": "4.114.0"
+  },
+  "overrides": {
+    "undici": "7.29.0"
   }
 }


### PR DESCRIPTION
## Summary

- override the transitive Worker tooling dependency from `undici@7.28.0` to patched `undici@7.29.0`
- update the npm lockfile without changing Wrangler, Miniflare, or the deployed Worker
- clear five current Dependabot alerts, including the high-severity cache parsing advisory

## Root cause and exposure

`wrangler@4.114.0` pins `miniflare@4.20260722.0`, which pins vulnerable `undici@7.28.0`. The existing Dependabot Wrangler 4.117.0 update also resolves Miniflare to an `undici@7.28.0` dependency, so upgrading Wrangler alone does not clear the alerts.

The dependency is development-only and is not present in the generated Cloudflare Worker bundle. This patch still removes the exposure from local development and CI and restores the repository's high-severity audit gate.

Affected advisories:

- GHSA-4cwx-7wf7-3272 (high)
- GHSA-8xcm-r25x-g524
- GHSA-jr45-8vmc-qm54
- GHSA-m8rv-5g2x-5cg5
- GHSA-v3r7-h72x-cjcm

## Validation

- `npm ci`: passed
- `npm audit --audit-level=high`: 0 vulnerabilities
- `npm test`: 53/53 passed
- `npm run cf:check`: passed
- `npm run cf:check:staging`: passed
- `npm ls undici miniflare wrangler --all`: confirms `undici@7.29.0 overridden`
- `git diff --check`: passed